### PR TITLE
feat: GitHub Actions CI 워크플로우 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, develop]
+
+jobs:
+  # ─────────────────────────────────────────────
+  # 1. ESLint 린트 검사
+  # ─────────────────────────────────────────────
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  # ─────────────────────────────────────────────
+  # 2. TypeScript 타입 체크
+  # ─────────────────────────────────────────────
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run type-check
+
+  # ─────────────────────────────────────────────
+  # 3. Next.js 빌드 (lint + type-check 통과 후)
+  # ─────────────────────────────────────────────
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, type-check]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+
+  # ─────────────────────────────────────────────
+  # 4. Discord 실패 알림
+  # ─────────────────────────────────────────────
+  discord-ci-failure:
+    name: Discord CI 실패 알림
+    runs-on: ubuntu-latest
+    needs: [lint, type-check, build]
+    if: failure()
+    steps:
+      - name: Discord 알림 전송
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: failure
+          title: "CI 검사 실패"
+          description: |
+            PR: ${{ github.event.pull_request.title }}
+            작성자: @${{ github.event.pull_request.user.login }}
+            베이스: `${{ github.event.pull_request.base.ref }}` ← `${{ github.event.pull_request.head.ref }}`
+          url: ${{ github.event.pull_request.html_url }}
+          username: "Flooding Client Bot"
+          avatar_url: ${{ secrets.DISCORD_AVATAR_URL }}
+          color: "0xFF0000"
+          nofail: true
+          nocontext: true
+          noprefix: true
+          notimestamp: false
+          ack_no_webhook: true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@sun-typeface/suit": "^2.0.5",


### PR DESCRIPTION
## #️⃣연관된 이슈

#11

## 📝작업 내용

PR 머지 전 코드 품질을 자동으로 검증하는 CI 워크플로우를 추가합니다.

- `package.json`에 `type-check` 스크립트 추가 (`tsc --noEmit`)
- `.github/workflows/ci.yml` 신규 생성

**트리거**: `main`, `develop` 브랜치를 대상으로 하는 PR (opened, synchronize, reopened)

**잡 실행 순서**:
1. `lint` + `type-check` — 병렬 실행
2. `build` — lint, type-check 통과 후 실행
3. `discord-ci-failure` — 위 잡 중 하나라도 실패하면 Discord 알림 전송

기존 `pr-automation.yml`에서 사용하는 `sarisia/actions-status-discord@v1`, `DISCORD_WEBHOOK`, `DISCORD_AVATAR_URL` 시크릿을 그대로 재사용합니다.

## 💬리뷰 요구사항(선택)

lint, type-check를 병렬로 실행한 뒤 build를 순차 실행하는 구조가 적절한지 확인 부탁드립니다.