### PR TITLE
chore: 기숙사 UI 간격 조정

### DIFF
--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -84,9 +84,9 @@ export function SelfStudySection() {
   });
 
   return (
-    <section className="bg-background-surface rounded-2xl p-6 flex flex-col gap-6">
+    <section className="bg-background-surface rounded-2xl p-6 flex flex-col gap-4">
       <div className="flex items-end gap-3">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
           <ApplyStudy />
           <span className="text-main-text text-text-1">자습신청</span>
         </div>

--- a/src/shared/ui/ProfileCard.tsx
+++ b/src/shared/ui/ProfileCard.tsx
@@ -10,7 +10,7 @@ interface ProfileCardProps {
 export function ProfileCard({ index, student }: ProfileCardProps) {
   return (
     <div className="relative w-[170px] h-[165px] bg-sub-4 rounded-2xl">
-      <span className="absolute top-3 left-4 text-caption-3 text-sub-1">
+      <span className="absolute top-4 left-4 text-caption-3 text-sub-1">
         {index}
       </span>
       <div className="flex flex-col items-center justify-center gap-2 py-6">


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

기숙사 관련 UI 컴포넌트의 간격(spacing) 값을 조정했습니다.

- **`SelfStudySection`** (`src/features/self-study/ui/SelfStudySection.tsx`)
  - 섹션 전체 세로 간격: `gap-6` → `gap-4`
  - 자습신청 아이콘·텍스트 간격: `gap-2` → `gap-1`
- **`ProfileCard`** (`src/shared/ui/ProfileCard.tsx`)
  - 인덱스 번호 상단 위치: `top-3` → `top-4`

<img width="254" height="232" alt="2026-03-11_16-04-33" src="https://github.com/user-attachments/assets/9f957f94-b551-498b-97da-e89b99c1d96b" />
  
<img width="899" height="317" alt="2026-03-11_16-04-22" src="https://github.com/user-attachments/assets/56636c45-0b62-44c9-b11c-9069ae9aaa28" />

<img width="230" height="268" alt="image" src="https://github.com/user-attachments/assets/3c3b9409-f3c7-4bad-b686-52e2e299fa1d" />
