### PR TITLE
fix: 헤더 시계 로직을 Clock 컴포넌트로 분리

### DIFF
--- a/src/widgets/header/ui/clock.tsx
+++ b/src/widgets/header/ui/clock.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+function pad(n: number) {
+  return String(n).padStart(2, "0");
+}
+
+export function Clock() {
+  const [time, setTime] = useState("");
+  const [date, setDate] = useState("");
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    const tick = () => {
+      const now = new Date();
+      setTime(
+        `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`,
+      );
+      setDate(
+        `${String(now.getFullYear()).slice(2)}.${pad(now.getMonth() + 1)}.${pad(now.getDate())}`,
+      );
+      timerRef.current = setTimeout(tick, 1000 - now.getMilliseconds());
+    };
+    tick();
+    return () => clearTimeout(timerRef.current);
+  }, []);
+
+  return (
+    <div className="flex bg-background-surface items-end p-2 gap-2 rounded-lg">
+      <span className="tabular-nums text-title-2 text-main-text">{time}</span>
+      <span className="text-text-4 text-sub-1">{date}</span>
+    </div>
+  );
+}

--- a/src/widgets/header/ui/header.tsx
+++ b/src/widgets/header/ui/header.tsx
@@ -1,44 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { DarkModeToggle } from "@/shared/ui/Toggle/DarkModeToggle";
 import { getPathLabel } from "@/shared/config/routes";
 import { usePathname } from "next/navigation";
+import { Clock } from "./clock";
 
 export function Header() {
-  const [time, setTime] = useState("");
-  const [date, setDate] = useState("");
-
   const path = usePathname();
-
-  useEffect(() => {
-    const update = () => {
-      const now = new Date();
-      const hh = String(now.getHours()).padStart(2, "0");
-      const mm = String(now.getMinutes()).padStart(2, "0");
-      const ss = String(now.getSeconds()).padStart(2, "0");
-      setTime(`${hh}:${mm}:${ss}`);
-
-      const yy = String(now.getFullYear()).slice(2);
-      const mo = String(now.getMonth() + 1).padStart(2, "0");
-      const dd = String(now.getDate()).padStart(2, "0");
-      setDate(`${yy}.${mo}.${dd}`);
-    };
-    update();
-    const id = setInterval(update, 1000);
-    return () => clearInterval(id);
-  }, []);
 
   return (
     <header className="flex items-center justify-between px-8 lg:px-10 2xl:px-18 pt-8 lg:pt-13 pb-6 2xl:pb-8 bg-transparent">
       <div className="flex items-center gap-4">
         <h1 className="text-main-text text-title-2">{getPathLabel(path)}</h1>
-        <div className="flex bg-background-surface items-end p-2 gap-2 rounded-lg">
-          <span className="tabular-nums text-title-2 text-main-text">
-            {time}
-          </span>
-          <span className="text-text-4 text-sub-1">{date}</span>
-        </div>
+        <Clock />
       </div>
       <DarkModeToggle />
     </header>


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

헤더 컴포넌트에 인라인으로 작성되어 있던 시계(시간/날짜) 로직을 별도의 `Clock` 컴포넌트(`widgets/header/ui/clock.tsx`)로 분리했습니다. 이를 통해 불필요하게 리렌더링 되고 있던 헤더 컴포넌트를 `Clock` 컴포넌트만 리렌더링 되도록 변경하였습니다.

- `Clock` 컴포넌트: `useEffect` + `setTimeout` 기반 정확한 초 동기화 로직, 시간/날짜 상태 관리
- `Header` 컴포넌트: 기존 시계 로직 제거 후 `<Clock />` 컴포넌트로 교체
- `setInterval` → `setTimeout` 방식으로 변경해 매 초 시작 시점에 정확히 갱신되도록 개선

기존

https://github.com/user-attachments/assets/9f18b01e-2e9b-43dd-b77b-d07165b9f315



개선 후

https://github.com/user-attachments/assets/b883fcba-da61-4353-89cb-8ca70b594384


