### PR TITLE
feat: 홈베이스 부분 목데이터 TanStack Query 기반으로 전환

### DIFF
--- a/src/features/homebase/api/get-homebase.ts
+++ b/src/features/homebase/api/get-homebase.ts
@@ -1,0 +1,7 @@
+import { instance } from '@/shared/api/instance';
+import type { HomebaseReservation } from '../model/types';
+
+export async function getHomebase(): Promise<HomebaseReservation[]> {
+  const { data } = await instance.get<HomebaseReservation[]>('/homebase');
+  return data;
+}

--- a/src/features/homebase/api/homebase.handlers.ts
+++ b/src/features/homebase/api/homebase.handlers.ts
@@ -1,0 +1,42 @@
+import { http, HttpResponse } from 'msw';
+import type { HomebaseReservation } from '../model/types';
+
+const mockHomebaseList: HomebaseReservation[] = [
+  {
+    id: 1,
+    startPeriod: 8,
+    endPeriod: 9,
+    homebaseId: 1,
+    members: [
+      { studentNumber: '2501', name: '박건우' },
+      { studentNumber: '2502', name: '이수진' },
+    ],
+  },
+  {
+    id: 2,
+    startPeriod: 10,
+    endPeriod: 11,
+    homebaseId: 4,
+    members: [
+      { studentNumber: '1301', name: '김태양' },
+      { studentNumber: '1302', name: '최아름' },
+      { studentNumber: '3401', name: '정민호' },
+    ],
+  },
+];
+
+export const homebaseHandlers = [
+  http.get('/homebase', () => HttpResponse.json(mockHomebaseList)),
+
+  http.post('/homebase/:homebaseId', () =>
+    HttpResponse.json({}, { status: 201 })
+  ),
+
+  http.delete('/homebase/:homebaseId', () =>
+    new HttpResponse(null, { status: 204 })
+  ),
+
+  http.patch('/homebase/:homebaseId', () =>
+    new HttpResponse(null, { status: 204 })
+  ),
+];

--- a/src/features/homebase/api/homebase.handlers.ts
+++ b/src/features/homebase/api/homebase.handlers.ts
@@ -1,5 +1,5 @@
-import { http, HttpResponse } from 'msw';
-import type { HomebaseReservation } from '../model/types';
+import { http, HttpResponse } from "msw";
+import type { HomebaseReservation } from "../model/types";
 
 const mockHomebaseList: HomebaseReservation[] = [
   {
@@ -7,9 +7,10 @@ const mockHomebaseList: HomebaseReservation[] = [
     startPeriod: 8,
     endPeriod: 9,
     homebaseId: 1,
+    reason: "회의",
     members: [
-      { studentNumber: '2501', name: '박건우' },
-      { studentNumber: '2502', name: '이수진' },
+      { studentNumber: "2501", name: "박건우" },
+      { studentNumber: "2502", name: "이수진" },
     ],
   },
   {
@@ -17,26 +18,29 @@ const mockHomebaseList: HomebaseReservation[] = [
     startPeriod: 10,
     endPeriod: 11,
     homebaseId: 4,
+    reason: "스터디",
     members: [
-      { studentNumber: '1301', name: '김태양' },
-      { studentNumber: '1302', name: '최아름' },
-      { studentNumber: '3401', name: '정민호' },
+      { studentNumber: "1301", name: "김태양" },
+      { studentNumber: "1302", name: "최아름" },
+      { studentNumber: "3401", name: "정민호" },
     ],
   },
 ];
 
 export const homebaseHandlers = [
-  http.get('/homebase', () => HttpResponse.json(mockHomebaseList)),
+  http.get("/homebase", () => HttpResponse.json(mockHomebaseList)),
 
-  http.post('/homebase/:homebaseId', () =>
-    HttpResponse.json({}, { status: 201 })
+  http.post("/homebase/:homebaseId", () =>
+    HttpResponse.json({}, { status: 201 }),
   ),
 
-  http.delete('/homebase/:homebaseId', () =>
-    new HttpResponse(null, { status: 204 })
+  http.delete(
+    "/homebase/:homebaseId",
+    () => new HttpResponse(null, { status: 204 }),
   ),
 
-  http.patch('/homebase/:homebaseId', () =>
-    new HttpResponse(null, { status: 204 })
+  http.patch(
+    "/homebase/:homebaseId",
+    () => new HttpResponse(null, { status: 204 }),
   ),
 ];

--- a/src/features/homebase/api/homebase.queries.ts
+++ b/src/features/homebase/api/homebase.queries.ts
@@ -1,0 +1,23 @@
+import { queryOptions } from '@tanstack/react-query';
+import { instance } from '@/shared/api/instance';
+import { getHomebase } from './get-homebase';
+import type { HomebaseApplyRequest, HomebasePatchRequest } from '../model/types';
+
+export const homebaseQueries = {
+  list: () =>
+    queryOptions({
+      queryKey: ['homebase'],
+      queryFn: getHomebase,
+    }),
+} as const;
+
+export const homebaseMutations = {
+  apply: (homebaseId: number, body: HomebaseApplyRequest) =>
+    instance.post(`/homebase/${homebaseId}`, body),
+
+  cancel: (homebaseId: number) =>
+    instance.delete(`/homebase/${homebaseId}`),
+
+  update: (homebaseId: number, body: HomebasePatchRequest) =>
+    instance.patch(`/homebase/${homebaseId}`, body),
+};

--- a/src/features/homebase/model/types.ts
+++ b/src/features/homebase/model/types.ts
@@ -1,0 +1,23 @@
+export interface HomebaseMember {
+  studentNumber: string;
+  name: string;
+}
+
+export interface HomebaseReservation {
+  id: number;
+  startPeriod: number;
+  endPeriod: number;
+  homebaseId: number;
+  members: HomebaseMember[];
+}
+
+export interface HomebaseApplyRequest {
+  homebaseId: number;
+  startPeriod: number;
+  endPeriod: number;
+  members: HomebaseMember[];
+}
+
+export interface HomebasePatchRequest {
+  members: HomebaseMember[];
+}

--- a/src/features/homebase/model/types.ts
+++ b/src/features/homebase/model/types.ts
@@ -8,6 +8,7 @@ export interface HomebaseReservation {
   startPeriod: number;
   endPeriod: number;
   homebaseId: number;
+  reason: string;
   members: HomebaseMember[];
 }
 
@@ -15,6 +16,7 @@ export interface HomebaseApplyRequest {
   homebaseId: number;
   startPeriod: number;
   endPeriod: number;
+  reason: string;
   members: HomebaseMember[];
 }
 

--- a/src/shared/api/msw/handlers.ts
+++ b/src/shared/api/msw/handlers.ts
@@ -1,3 +1,4 @@
 import { dormitoryHandlers } from '@/entities/dormitory/api/dormitory.handlers';
+import { homebaseHandlers } from '@/features/homebase/api/homebase.handlers';
 
-export const handlers = [...dormitoryHandlers];
+export const handlers = [...dormitoryHandlers, ...homebaseHandlers];

--- a/src/widgets/main/ui/HomebaseCard.tsx
+++ b/src/widgets/main/ui/HomebaseCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import HomeBase from "@/shared/asset/svg/HomeBase";
 import Search from "@/shared/asset/svg/Search";
 import TextField from "@/shared/ui/textField";
@@ -12,10 +13,9 @@ import StudentSearch from "@/features/homebase/ui/StudentSearch";
 import SelectedStudent from "@/features/homebase/ui/SelectedStudent";
 import { User } from "@/entities/user/model/user";
 import { ReservationTableItem } from "@/entities/school/ui/ReservationTableItem";
-import {
-  MOCK_RESERVATIONS,
-  MOCK_MY_RESERVATION,
-} from "@/entities/school/model/mock";
+import { homebaseQueries, homebaseMutations } from "@/features/homebase/api/homebase.queries";
+import type { HomebaseReservation, HomebaseApplyRequest } from "@/features/homebase/model/types";
+import type { Reservation } from "@/entities/school/model/reservation";
 
 const FLOORS = [
   { value: "2F", label: "2층" },
@@ -38,6 +38,51 @@ export const TABLE_MAX_PERSONNEL = {
   "4F": { "1": 6, "2": 6, "3": 4, "4": 4 },
 } as const;
 
+// homebaseId ↔ { floor, tableName } 매핑
+// 실제 백엔드 homebaseId 값에 맞게 수정 필요
+const HOMEBASE_ID_MAP: Record<number, { floor: string; tableName: string }> = {
+  1: { floor: "2F", tableName: "테이블 1" },
+  2: { floor: "2F", tableName: "테이블 2" },
+  3: { floor: "2F", tableName: "테이블 3" },
+  4: { floor: "3F", tableName: "테이블 1" },
+  5: { floor: "3F", tableName: "테이블 2" },
+  6: { floor: "3F", tableName: "테이블 3" },
+  7: { floor: "3F", tableName: "테이블 5" },
+  8: { floor: "3F", tableName: "테이블 6" },
+  9: { floor: "4F", tableName: "테이블 1" },
+  10: { floor: "4F", tableName: "테이블 2" },
+  11: { floor: "4F", tableName: "테이블 3" },
+  12: { floor: "4F", tableName: "테이블 4" },
+};
+
+const FLOOR_TABLE_TO_ID: Record<string, number> = Object.fromEntries(
+  Object.entries(HOMEBASE_ID_MAP).map(([id, { floor, tableName }]) => [
+    `${floor}-${tableName.replace("테이블 ", "")}`,
+    Number(id),
+  ])
+);
+
+function toReservation(r: HomebaseReservation): Reservation {
+  const { floor, tableName } = HOMEBASE_ID_MAP[r.homebaseId] ?? {
+    floor: "?F",
+    tableName: `테이블 ${r.homebaseId}`,
+  };
+
+  const periods: string[] = [];
+  for (let p = r.startPeriod; p <= r.endPeriod; p++) {
+    periods.push(`${p}교시`);
+  }
+
+  return {
+    id: r.id,
+    tableName,
+    floor,
+    members: r.members.map((m) => `${m.studentNumber} ${m.name}`),
+    periods,
+    reason: "",
+  };
+}
+
 export default function HomebaseCard({
   showReservations = false,
 }: {
@@ -49,6 +94,20 @@ export default function HomebaseCard({
   const [reason, setReason] = useState("");
   const [selectedTable, setSelectedTable] = useState<string | null>(null);
   const [selectedStudents, setSelectedStudents] = useState<User[]>([]);
+
+  const queryClient = useQueryClient();
+  const { data: reservations = [] } = useQuery(homebaseQueries.list());
+
+  const applyMutation = useMutation({
+    mutationFn: ({ homebaseId, body }: { homebaseId: number; body: HomebaseApplyRequest }) =>
+      homebaseMutations.apply(homebaseId, body),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["homebase"] }),
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (homebaseId: number) => homebaseMutations.cancel(homebaseId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["homebase"] }),
+  });
 
   const isPeriodStarted = (period: string) => {
     const now = new Date();
@@ -102,9 +161,33 @@ export default function HomebaseCard({
   const isFull = maxPersonnel > 0 && selectedStudents.length >= maxPersonnel;
   const canSubmit = selectedTable && isFull && reason.trim().length > 0;
 
-  const filteredReservations = MOCK_RESERVATIONS.filter(
-    (r) => r.floor === selectedFloor,
-  );
+  const handleSubmit = () => {
+    if (!canSubmit || !selectedTable) return;
+
+    const periodIndex = PERIODS.indexOf(selectedPeriod);
+    const startPeriod = 8 + periodIndex;
+    const homebaseId = FLOOR_TABLE_TO_ID[`${selectedFloor}-${selectedTable}`];
+
+    applyMutation.mutate({
+      homebaseId,
+      body: {
+        homebaseId,
+        startPeriod,
+        endPeriod: startPeriod,
+        members: selectedStudents.map((s) => ({
+          studentNumber: String(s.studentNumber),
+          name: s.name,
+        })),
+      },
+    });
+  };
+
+  const filteredReservations = reservations
+    .filter((r) => (HOMEBASE_ID_MAP[r.homebaseId]?.floor ?? "") === selectedFloor)
+    .map(toReservation);
+
+  // 내 예약: 로그인 유저 기준으로 필터링 필요 — 임시로 첫 번째 항목
+  const myReservation = reservations.length > 0 ? toReservation(reservations[0]) : null;
 
   return (
     <div className="w-full bg-background-surface rounded-2xl p-6 flex flex-col">
@@ -150,8 +233,8 @@ export default function HomebaseCard({
       <div className="flex flex-col lg:flex-row items-start gap-6 2xl:justify-between mt-3">
         <div className="w-full lg:flex-1 min-w-0">{renderFloor()}</div>
 
-        <div className="w-full lg:shrink-0 flex flex-col sm:flex-row gap-6 lg:w-[330px] lg:flex-col lg:gap-4">
-          <div className="w-full sm:w-[300px] lg:w-full shrink-0 flex flex-col gap-4">
+        <div className="w-full lg:shrink-0 flex flex-col sm:flex-row gap-6 lg:w-82.5 lg:flex-col lg:gap-4">
+          <div className="w-full sm:w-75 lg:w-full shrink-0 flex flex-col gap-4">
             <div className="flex flex-col gap-1">
               <TextField
                 placeholder="이름, 학번등을 입력해주세요"
@@ -173,7 +256,7 @@ export default function HomebaseCard({
                 value={reason}
                 maxLength={20}
                 onChange={(e) => setReason(e.target.value)}
-                className="w-full h-[120px] rounded-lg border border-sub-2 bg-background-surface text-main-text placeholder:text-sub-2 focus:border-sub-1 outline-none p-4 resize-none caret-p-1 transition-all"
+                className="w-full h-30 rounded-lg border border-sub-2 bg-background-surface text-main-text placeholder:text-sub-2 focus:border-sub-1 outline-none p-4 resize-none caret-p-1 transition-all"
               />
               <span className="text-right text-sub-2 text-size-caption-1">
                 {reason.length}/20
@@ -184,6 +267,7 @@ export default function HomebaseCard({
               <TextButton
                 variant={canSubmit ? "filled" : "disabled"}
                 size="wide"
+                onClick={handleSubmit}
               >
                 신청하기
               </TextButton>
@@ -209,8 +293,13 @@ export default function HomebaseCard({
               <span className="font-semibold text-sub-1 text-text-2 text-center">
                 내 예약현황
               </span>
-              {MOCK_MY_RESERVATION ? (
-                <ReservationTableItem reservation={MOCK_MY_RESERVATION} isOwn />
+              {myReservation ? (
+                <ReservationTableItem
+                  reservation={myReservation}
+                  isOwn
+                  onDelete={() => cancelMutation.mutate(reservations[0].homebaseId)}
+                  onEdit={() => {}}
+                />
               ) : (
                 <div className="flex flex-1 items-center justify-center">
                   <span className="text-sub-2 text-text-4">

--- a/src/widgets/main/ui/HomebaseCard.tsx
+++ b/src/widgets/main/ui/HomebaseCard.tsx
@@ -79,7 +79,7 @@ function toReservation(r: HomebaseReservation): Reservation {
     floor,
     members: r.members.map((m) => `${m.studentNumber} ${m.name}`),
     periods,
-    reason: "",
+    reason: r.reason,
   };
 }
 
@@ -174,6 +174,7 @@ export default function HomebaseCard({
         homebaseId,
         startPeriod,
         endPeriod: startPeriod,
+        reason,
         members: selectedStudents.map((s) => ({
           studentNumber: String(s.studentNumber),
           name: s.name,

--- a/src/widgets/main/ui/HomebaseCard.tsx
+++ b/src/widgets/main/ui/HomebaseCard.tsx
@@ -38,26 +38,27 @@ export const TABLE_MAX_PERSONNEL = {
   "4F": { "1": 6, "2": 6, "3": 4, "4": 4 },
 } as const;
 
-// homebaseId ↔ { floor, tableName } 매핑
+// homebaseId ↔ { floor, tableId, tableName } 매핑
+// tableId: Floor 컴포넌트의 selectedTable 값과 일치하는 식별자
 // 실제 백엔드 homebaseId 값에 맞게 수정 필요
-const HOMEBASE_ID_MAP: Record<number, { floor: string; tableName: string }> = {
-  1: { floor: "2F", tableName: "테이블 1" },
-  2: { floor: "2F", tableName: "테이블 2" },
-  3: { floor: "2F", tableName: "테이블 3" },
-  4: { floor: "3F", tableName: "테이블 1" },
-  5: { floor: "3F", tableName: "테이블 2" },
-  6: { floor: "3F", tableName: "테이블 3" },
-  7: { floor: "3F", tableName: "테이블 5" },
-  8: { floor: "3F", tableName: "테이블 6" },
-  9: { floor: "4F", tableName: "테이블 1" },
-  10: { floor: "4F", tableName: "테이블 2" },
-  11: { floor: "4F", tableName: "테이블 3" },
-  12: { floor: "4F", tableName: "테이블 4" },
+const HOMEBASE_ID_MAP: Record<number, { floor: string; tableId: string; tableName: string }> = {
+  1: { floor: "2F", tableId: "1", tableName: "테이블 1" },
+  2: { floor: "2F", tableId: "2", tableName: "테이블 2" },
+  3: { floor: "2F", tableId: "3", tableName: "테이블 3" },
+  4: { floor: "3F", tableId: "1", tableName: "테이블 1" },
+  5: { floor: "3F", tableId: "2", tableName: "테이블 2" },
+  6: { floor: "3F", tableId: "3", tableName: "테이블 3" },
+  7: { floor: "3F", tableId: "5", tableName: "테이블 5" },
+  8: { floor: "3F", tableId: "6", tableName: "테이블 6" },
+  9: { floor: "4F", tableId: "1", tableName: "테이블 1" },
+  10: { floor: "4F", tableId: "2", tableName: "테이블 2" },
+  11: { floor: "4F", tableId: "3", tableName: "테이블 3" },
+  12: { floor: "4F", tableId: "4", tableName: "테이블 4" },
 };
 
 const FLOOR_TABLE_TO_ID: Record<string, number> = Object.fromEntries(
-  Object.entries(HOMEBASE_ID_MAP).map(([id, { floor, tableName }]) => [
-    `${floor}-${tableName.replace("테이블 ", "")}`,
+  Object.entries(HOMEBASE_ID_MAP).map(([id, { floor, tableId }]) => [
+    `${floor}-${tableId}`,
     Number(id),
   ])
 );


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

홈베이스 섹션의 하드코딩된 목데이터를 MSW + TanStack Query 기반으로 전환합니다.

**API 레이어 구현** (`features/homebase/`)
- `model/types.ts` — `HomebaseReservation`, `HomebaseMember`, `HomebaseApplyRequest`, `HomebasePatchRequest` 타입 정의
- `api/get-homebase.ts` — `GET /homebase` 함수
- `api/homebase.queries.ts` — `homebaseQueries.list()` Query Factory + `homebaseMutations` (apply / cancel / update)
- `api/homebase.handlers.ts` — MSW 목 핸들러 (GET, POST, DELETE, PATCH)

**MSW 핸들러 등록**
- `shared/api/msw/handlers.ts`에 `homebaseHandlers` 추가

**UI 연동** (`widgets/main/ui/HomebaseCard.tsx`)
- `MOCK_RESERVATIONS` / `MOCK_MY_RESERVATION` 제거
- 예약 목록 조회 → `useQuery(homebaseQueries.list())`
- 신청 → `applyMutation`, 취소 → `cancelMutation`
- API 응답을 `ReservationTableItem` 형태로 변환하는 `toReservation` 헬퍼 추가

## 💬리뷰 요구사항(선택)

**`HOMEBASE_ID_MAP` 확인 필요**
`homebaseId → 층/테이블명` 매핑을 임시로 1~12로 설정했습니다. 실제 백엔드 DB의 homebaseId 값이 확정되면 수정이 필요합니다.

**내 예약 필터링 미구현**
`myReservation`은 현재 목록의 첫 번째 항목으로 임시 처리했습니다. 로그인 유저 기준 필터링은 인증 연동 후 별도 작업이 필요합니다.
