### PR TITLE
change: DataGSM 인증 흐름 변경

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -31,6 +31,17 @@ allowed-tools: Read
 - Confirm the branch name with the user before creating it.
 - After confirmation, create and checkout the branch with `git checkout -b <branch-name>`, then commit on that branch.
 - If the current branch is not `develop`, continue with the normal commit flow.
+- Before staging or committing, inspect the current changes with `git status --short`, `git diff --stat`, and file-level diffs as needed.
+- Group changed files by commit intent autonomously. Do not default to a single commit when unrelated changes are present.
+- Present the planned commit groups to the user before staging:
+  - files included in each group
+  - commit type
+  - Korean commit message
+- Get explicit user approval for each commit group before staging or committing that group.
+- Request any required tool or sandbox permission approvals before running `git add`, `git commit`, or `git checkout -b`.
+- Treat tool/sandbox permission approval separately from commit-content approval. A permission approval does not approve the commit contents.
+- After each approved commit, re-check the remaining changes and repeat the grouping and approval flow until no intended changes remain.
+- If the user says "commit now" or "바로 커밋", still split commits by intent when multiple independent changes are present.
 
 ## Rules
 
@@ -39,3 +50,6 @@ allowed-tools: Read
 - File naming follows project conventions by role; Markdown documents are an exception
 - Keep commits focused and atomic
 - Write commit messages in the smallest possible units.
+- A single commit must represent a single intent.
+- Split package updates, configuration changes, documentation changes, feature changes, refactors, and file moves into separate commits when possible.
+- Keep related lockfile and manifest changes together, such as `package.json` with `package-lock.json`.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -20,8 +20,17 @@ allowed-tools: Read
 
 ## Branching Strategy
 
-- Branch format: `type/description` (e.g., `feat/기능명`, `fix/버그수정`, `docs/문서개선`, `refactor/리팩토링`)
+- Branch format: `type/description` (e.g., `feat/add-login`, `fix/token-refresh`, `docs/update-rules`, `refactor/improve-layout`)
 - Merge via PR → `develop`
+
+## Commit Workflow
+
+- Before committing, check the current branch.
+- If the current branch is `develop`, do not commit directly.
+- Propose a new branch name using the `type/description` format based on the intended commit.
+- Confirm the branch name with the user before creating it.
+- After confirmation, create and checkout the branch with `git checkout -b <branch-name>`, then commit on that branch.
+- If the current branch is not `develop`, continue with the normal commit flow.
 
 ## Rules
 

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,5 +1,7 @@
 # Flooding-Client-V2 Style Guide
 
+Please respond and work in Korean.
+
 This repository uses the rule files in `.claude/rules` as the source of truth for code review. When reviewing code in this repository, apply the referenced files directly and prefer them over inferred defaults or external conventions.
 
 Referenced rule files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 "📩 Type: Feature/Function":
   - head-branch:
-      ["^feat/.+", "^feature/.+", "^refactor/.+", "^chore/.+", "^ci/.+"]
+      ["^feat/.+", "^feature/.+", "^change/.+", "^refactor/.+", "^chore/.+", "^ci/.+"]
 
 "🐞 Type: Bug/Function":
   - head-branch: ["^fix/.+", "^hotfix/.+", "^bugfix/.+"]

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -3,51 +3,44 @@ import { NextRequest, NextResponse } from "next/server";
 import { instance } from "@/shared/api/instance";
 
 export async function POST(request: NextRequest) {
-  const { code, codeVerifier } = await request.json();
-
-  let accessToken: string;
-  let refreshToken: string;
+  const { code } = await request.json();
 
   try {
-    const { data: body } = await instance.post(process.env.DATAGSM_TOKEN_URL!, {
-      grant_type: "authorization_code",
-      code,
-      client_id: process.env.NEXT_PUBLIC_DG_CLIENT_ID,
-      redirect_uri: process.env.NEXT_PUBLIC_DG_REDIRECT_URL,
-      code_verifier: codeVerifier,
-    });
-    accessToken = body.data.access_token;
-    refreshToken = body.data.refresh_token;
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      return NextResponse.json({ error: "토큰 교환 실패" }, { status: 400 });
-    }
-    return NextResponse.json({ error: "알 수 없는 오류" }, { status: 500 });
-  }
+    const signinUrl = `${process.env.NEXT_PUBLIC_BASE_URL!}/auth/signin`;
+    const signinBody = {
+      authCode: code,
+      redirectUri: process.env.NEXT_PUBLIC_DG_REDIRECT_URL!,
+    };
 
-  try {
-    const { data: user } = await instance.get(
-      process.env.DATAGSM_USERINFO_URL!,
-      {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      },
-    );
-    const response = NextResponse.json({ accessToken, user });
-    response.cookies.set("refresh_token", refreshToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      path: "/api/auth",
-      maxAge: 30 * 24 * 60 * 60,
+    console.log("auth/signin request:", {
+      url: signinUrl,
+      body: signinBody,
     });
-    return response;
+
+    const response = await instance.post(signinUrl, signinBody);
+
+    console.log("auth/signin response:", {
+      status: response.status,
+      headers: response.headers,
+      data: response.data,
+    });
+
+    return NextResponse.json(response.data, {
+      status: response.status,
+    });
   } catch (error) {
-    if (axios.isAxiosError(error)) {
-      return NextResponse.json(
-        { error: "유저 정보 조회 실패" },
-        { status: 400 },
-      );
+    if (axios.isAxiosError(error) && error.response) {
+      console.log("auth/signin error:", {
+        status: error.response.status,
+        headers: error.response.headers,
+        data: error.response.data,
+      });
+
+      return NextResponse.json(error.response.data, {
+        status: error.response.status,
+      });
     }
-    return NextResponse.json({ error: "알 수 없는 오류" }, { status: 500 });
+
+    throw error;
   }
 }

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { HttpStatusCode } from "axios";
 import { NextRequest, NextResponse } from "next/server";
 import { instance } from "@/shared/api/instance";
 
@@ -12,35 +12,33 @@ export async function POST(request: NextRequest) {
       redirectUri: process.env.NEXT_PUBLIC_DG_REDIRECT_URL!,
     };
 
-    console.log("auth/signin request:", {
-      url: signinUrl,
-      body: signinBody,
-    });
-
     const response = await instance.post(signinUrl, signinBody);
-
-    console.log("auth/signin response:", {
-      status: response.status,
-      headers: response.headers,
-      data: response.data,
-    });
 
     return NextResponse.json(response.data, {
       status: response.status,
     });
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      console.log("auth/signin error:", {
-        status: error.response.status,
-        headers: error.response.headers,
-        data: error.response.data,
-      });
+    const fallbackBody = { error: "Internal Server Error" };
 
-      return NextResponse.json(error.response.data, {
-        status: error.response.status,
-      });
+    if (axios.isAxiosError(error) && error.response) {
+      const { data, status } = error.response;
+      const body = data ?? fallbackBody;
+
+      if (status === HttpStatusCode.BadRequest) {
+        return NextResponse.json(body, { status });
+      }
+
+      if (status === HttpStatusCode.Unauthorized) {
+        return NextResponse.json(body, { status });
+      }
+
+      if (status === HttpStatusCode.InternalServerError) {
+        return NextResponse.json(body, { status });
+      }
     }
 
-    throw error;
+    return NextResponse.json(fallbackBody, {
+      status: HttpStatusCode.InternalServerError,
+    });
   }
 }

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { HttpStatusCode } from "axios";
 import { NextRequest, NextResponse } from "next/server";
 import { instance } from "@/shared/api/instance";
 
@@ -6,7 +6,10 @@ export async function GET(request: NextRequest) {
   const authorization = request.headers.get("Authorization");
 
   if (!authorization) {
-    return NextResponse.json({ error: "인증 토큰 없음" }, { status: 401 });
+    return NextResponse.json(
+      { error: "인증 토큰 없음" },
+      { status: HttpStatusCode.Unauthorized },
+    );
   }
 
   try {
@@ -18,9 +21,27 @@ export async function GET(request: NextRequest) {
     );
     return NextResponse.json(user.data);
   } catch (error) {
-    const status = axios.isAxiosError(error)
-      ? (error.response?.status ?? 500)
-      : 500;
-    return NextResponse.json({ error: "유저 정보 조회 실패" }, { status });
+    const fallbackBody = { error: "유저 정보 조회 실패" };
+
+    if (axios.isAxiosError(error) && error.response) {
+      const { data, status } = error.response;
+      const body = data ?? fallbackBody;
+
+      if (status === HttpStatusCode.BadRequest) {
+        return NextResponse.json(body, { status });
+      }
+
+      if (status === HttpStatusCode.Unauthorized) {
+        return NextResponse.json(body, { status });
+      }
+
+      if (status === HttpStatusCode.InternalServerError) {
+        return NextResponse.json(body, { status });
+      }
+    }
+
+    return NextResponse.json(fallbackBody, {
+      status: HttpStatusCode.InternalServerError,
+    });
   }
 }

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { HttpStatusCode } from "axios";
 import { NextRequest, NextResponse } from "next/server";
 import { instance } from "@/shared/api/instance";
 
@@ -6,7 +6,10 @@ export async function POST(request: NextRequest) {
   const refreshToken = request.cookies.get("refresh_token")?.value;
 
   if (!refreshToken) {
-    return NextResponse.json({ error: "refresh_token 없음" }, { status: 401 });
+    return NextResponse.json(
+      { error: "refresh_token 없음" },
+      { status: HttpStatusCode.Unauthorized },
+    );
   }
 
   try {
@@ -19,12 +22,27 @@ export async function POST(request: NextRequest) {
       status: response.status,
     });
   } catch (error) {
+    const fallbackBody = { error: "Internal Server Error" };
+
     if (axios.isAxiosError(error) && error.response) {
-      return NextResponse.json(error.response.data, {
-        status: error.response.status,
-      });
+      const { data, status } = error.response;
+      const body = data ?? fallbackBody;
+
+      if (status === HttpStatusCode.BadRequest) {
+        return NextResponse.json(body, { status });
+      }
+
+      if (status === HttpStatusCode.Unauthorized) {
+        return NextResponse.json(body, { status });
+      }
+
+      if (status === HttpStatusCode.InternalServerError) {
+        return NextResponse.json(body, { status });
+      }
     }
 
-    throw error;
+    return NextResponse.json(fallbackBody, {
+      status: HttpStatusCode.InternalServerError,
+    });
   }
 }

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -10,34 +10,21 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const { data: body } = await instance.post(process.env.DATAGSM_TOKEN_URL!, {
-      grant_type: "refresh_token",
-      refresh_token: refreshToken,
-      client_id: process.env.NEXT_PUBLIC_DG_CLIENT_ID,
+    const reissueUrl = process.env.NEXT_PUBLIC_BASE_URL! + "/auth/reissue";
+    const reissueBody = { refreshToken };
+
+    const response = await instance.post(reissueUrl, reissueBody);
+
+    return NextResponse.json(response.data, {
+      status: response.status,
     });
-
-    const newAccessToken: string = body.data.access_token;
-    const newRefreshToken: string = body.data.refresh_token;
-
-    const response = NextResponse.json({ accessToken: newAccessToken });
-    response.cookies.set("refresh_token", newRefreshToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      path: "/api/auth",
-      maxAge: 30 * 24 * 60 * 60,
-    });
-
-    return response;
   } catch (error) {
-    if (axios.isAxiosError(error)) {
-      const response = NextResponse.json(
-        { error: "토큰 갱신 실패" },
-        { status: 401 },
-      );
-      response.cookies.delete("refresh_token");
-      return response;
+    if (axios.isAxiosError(error) && error.response) {
+      return NextResponse.json(error.response.data, {
+        status: error.response.status,
+      });
     }
-    return NextResponse.json({ error: "알 수 없는 오류" }, { status: 500 });
+
+    throw error;
   }
 }

--- a/app/api/auth/signout/route.ts
+++ b/app/api/auth/signout/route.ts
@@ -1,8 +1,13 @@
-import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
 export async function POST() {
-  const cookieStore = await cookies();
-  cookieStore.delete("refresh_token");
-  return NextResponse.json({ success: true });
+  const response = NextResponse.json({ success: true });
+  response.cookies.set("refresh_token", "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/api/auth",
+    maxAge: 0,
+  });
+  return response;
 }

--- a/app/callback/page.tsx
+++ b/app/callback/page.tsx
@@ -1,15 +1,15 @@
 "use client";
 
+import axios from "axios";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useRef } from "react";
-import { useOAuth } from "@themoment-team/datagsm-oauth-react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { instance } from "@/shared/api/instance";
 
 function CallbackInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { getCodeVerifier, clearVerifier } = useOAuth();
   const didRun = useRef(false);
+  const [responseBody, setResponseBody] = useState<unknown>(null);
 
   useEffect(() => {
     if (didRun.current) return;
@@ -17,33 +17,40 @@ function CallbackInner() {
 
     const code = searchParams.get("code");
 
+    console.log(code);
+
     if (!code) {
       router.replace("/signin");
       return;
     }
 
-    const codeVerifier = getCodeVerifier();
-
     (async () => {
       try {
         const { data } = await instance.post("/api/auth/callback", {
           code,
-          codeVerifier,
         });
-        const { accessToken, user } = data;
 
-        sessionStorage.setItem("access_token", accessToken);
-        sessionStorage.setItem("user", JSON.stringify(user));
-        clearVerifier();
+        setResponseBody(data);
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response) {
+          setResponseBody(error.response.data);
+          return;
+        }
 
-        router.replace("/");
-      } catch {
-        router.replace("/signin");
+        setResponseBody({ error: String(error) });
       }
     })();
-  }, [router, searchParams, getCodeVerifier, clearVerifier]);
+  }, [router, searchParams]);
 
-  return <div>로그인 처리 중...</div>;
+  return (
+    <main className="min-h-screen bg-background p-6 text-main-text">
+      <pre className="whitespace-pre-wrap wrap-break-word rounded-lg bg-background-surface p-4 text-text-2">
+        {responseBody === null
+          ? "로그인 처리 중..."
+          : JSON.stringify(responseBody, null, 2)}
+      </pre>
+    </main>
+  );
 }
 
 export default function Callback() {

--- a/app/callback/page.tsx
+++ b/app/callback/page.tsx
@@ -1,23 +1,19 @@
 "use client";
 
-import axios from "axios";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef } from "react";
 import { instance } from "@/shared/api/instance";
 
 function CallbackInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const didRun = useRef(false);
-  const [responseBody, setResponseBody] = useState<unknown>(null);
 
   useEffect(() => {
     if (didRun.current) return;
     didRun.current = true;
 
     const code = searchParams.get("code");
-
-    console.log(code);
 
     if (!code) {
       router.replace("/signin");
@@ -29,28 +25,18 @@ function CallbackInner() {
         const { data } = await instance.post("/api/auth/callback", {
           code,
         });
+        const accessToken = data.data?.accessToken ?? data.accessToken;
 
-        setResponseBody(data);
-      } catch (error) {
-        if (axios.isAxiosError(error) && error.response) {
-          setResponseBody(error.response.data);
-          return;
-        }
+        sessionStorage.setItem("access_token", accessToken);
 
-        setResponseBody({ error: String(error) });
+        router.replace("/");
+      } catch {
+        router.replace("/signin");
       }
     })();
   }, [router, searchParams]);
 
-  return (
-    <main className="min-h-screen bg-background p-6 text-main-text">
-      <pre className="whitespace-pre-wrap wrap-break-word rounded-lg bg-background-surface p-4 text-text-2">
-        {responseBody === null
-          ? "로그인 처리 중..."
-          : JSON.stringify(responseBody, null, 2)}
-      </pre>
-    </main>
-  );
+  return <div>로그인 처리 중...</div>;
 }
 
 export default function Callback() {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -12,7 +12,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         <OAuthProvider
           clientId={process.env.NEXT_PUBLIC_DG_CLIENT_ID!}
           redirectUri={process.env.NEXT_PUBLIC_DG_REDIRECT_URL!}
-          authMode="PKCE"
+          authMode="STANDARD"
         >
           {children}
         </OAuthProvider>

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -7,11 +7,15 @@ import { useOAuth } from "@themoment-team/datagsm-oauth-react";
 export default function Signin() {
   const { login } = useOAuth();
 
+  const handleLogin = async () => {
+    await login();
+  };
+
   return (
     <div className="flex h-screen items-center justify-center overflow-hidden bg-background">
       <div className="flex flex-col items-center gap-6 w-fit h-fit bg-background-surface px-8 py-13 rounded-2xl">
         <Logo />
-        <TextButton variant="filled" size="wide" onClick={login}>
+        <TextButton variant="filled" size="wide" onClick={handleLogin}>
           Data GSM으로 로그인
         </TextButton>
       </div>

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
-  transpilePackages: ['msw'],
+  transpilePackages: ["msw"],
+  turbopack: {
+    root: process.cwd(),
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@sun-typeface/suit": "^2.0.5",
         "@tanstack/react-query": "^5.90.20",
         "@tanstack/react-query-devtools": "^5.91.3",
-        "@themoment-team/datagsm-oauth-react": "^1.1.0",
+        "@themoment-team/datagsm-oauth-react": "^1.1.1",
         "axios": "^1.13.4",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -1591,9 +1591,9 @@
       }
     },
     "node_modules/@themoment-team/datagsm-oauth-react": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@themoment-team/datagsm-oauth-react/-/datagsm-oauth-react-1.1.0.tgz",
-      "integrity": "sha512-Y/OGfyIoZn5R/azH5zDhYdE0w7ZelIYWO0zb4hq+yjzmxtFBcPm8Jp2S3QwbovBS8BLnMQb4ZUJ3wholN7kO7Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@themoment-team/datagsm-oauth-react/-/datagsm-oauth-react-1.1.1.tgz",
+      "integrity": "sha512-UlicDzMoUZvhtzRnwpIlRD0pJhGt/ng/iYaYT0Vt5GipIqX4ysdsr+QbpRrZJ7j8pExrI1J1bAhaWJ8dBMN/jw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@sun-typeface/suit": "^2.0.5",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-query-devtools": "^5.91.3",
-    "@themoment-team/datagsm-oauth-react": "^1.1.0",
+    "@themoment-team/datagsm-oauth-react": "^1.1.1",
     "axios": "^1.13.4",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -4,6 +4,12 @@ export const instance = axios.create({
   headers: { "Content-Type": "application/json" },
 });
 
+const authPathsWithoutRefresh = [
+  "/api/auth/callback",
+  "/api/auth/refresh",
+  "/api/auth/signout",
+];
+
 if (typeof window !== "undefined") {
   instance.interceptors.request.use((config) => {
     const token = sessionStorage.getItem("access_token");
@@ -21,14 +27,17 @@ if (typeof window !== "undefined") {
       if (
         error.response?.status === 401 &&
         !originalRequest._retried &&
-        !originalRequest.url?.includes("/api/auth/refresh")
+        !authPathsWithoutRefresh.some((path) =>
+          originalRequest.url?.includes(path),
+        )
       ) {
         originalRequest._retried = true;
 
         try {
           const { data } = await axios.post("/api/auth/refresh");
-          sessionStorage.setItem("access_token", data.accessToken);
-          originalRequest.headers.Authorization = `Bearer ${data.accessToken}`;
+          const accessToken = data.data?.accessToken ?? data.accessToken;
+          sessionStorage.setItem("access_token", accessToken);
+          originalRequest.headers.Authorization = `Bearer ${accessToken}`;
           return instance(originalRequest);
         } catch {
           sessionStorage.removeItem("access_token");


### PR DESCRIPTION
## #️⃣연관된 이슈

#50

## 📝작업 내용

- DataGSM OAuth 인증 방식을 `PKCE`에서 `STANDARD`로 변경했습니다.
- 인증 콜백 API가 DataGSM 토큰/유저 정보 API를 직접 호출하지 않도록 변경했습니다.
- 로그아웃 시 `refresh_token` 쿠키를 명시적으로 만료 처리하도록 수정했습니다.
- 클라이언트 API 인스턴스의 401 재시도 로직에서 인증 관련 API는 refresh 재시도 대상에서 제외했습니다.
- OAuth HTTP 문서의 상태 코드 기준에 맞춰 인증 API 에러 응답을 `400`, `401`, `500` 중심으로 명시 처리했습니다.
- Turbopack root 설정을 추가하고 DataGSM OAuth 패키지를 업데이트했습니다.
- 커밋 스킬 문서에 브랜치 생성 및 커밋 분할 승인 절차를 추가했습니다.