### PR TITLE
feat: 안마의자·자습 신청 API 연동 및 에러 처리

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,7 +1,6 @@
-import ApplyCard from "@/widgets/main/ui/ApplyCard";
+import MassageApplyCard from "@/widgets/main/ui/MassageApplyCard";
+import StudyApplyCard from "@/widgets/main/ui/StudyApplyCard";
 import MealCard from "@/widgets/main/ui/MealCard";
-import ChairIcon from "@/shared/asset/svg/Chair";
-import BookIcon from "@/shared/asset/svg/ApplyStudy";
 import ProfileCard from "@/widgets/main/ui/ProfileCard";
 import TimeTableCard from "@/widgets/main/ui/TimeTableCard";
 import HomebaseCard from "@/widgets/main/ui/HomebaseCard";
@@ -13,30 +12,14 @@ export default function MainPage() {
   return (
     <main className="flex-1 overflow-auto px-8 lg:px-10 2xl:px-18 pb-25">
       <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-[562fr_426fr_480fr] gap-x-4 gap-y-4 lg:gap-x-6 lg:gap-y-5 mb-4 lg:mb-5 2xl:mb-6">
-        <div className="flex flex-col gap-4 lg:gap-6 order-2 2xl:order-none 2xl:row-span-2">
-          <ApplyCard
-            title="자습신청"
-            icon={<BookIcon />}
-            current={4}
-            total={50}
-            timeText="자습 신청 시간은 20:00 ~ 21:00에 신청이 가능해요"
-            buttonText="신청 불가"
-            disabled
-          />
-          <ApplyCard
-            title="안마의자"
-            icon={<ChairIcon />}
-            current={4}
-            total={5}
-            timeText="안마 의자 신청 시간은 20:20 ~ 21:00에 신청이 가능해요"
-            buttonText="신청"
-            femaleNotice
-          />
+        <div className="flex flex-col gap-4 lg:gap-6 order-2 2xl:order-0 2xl:row-span-2">
+          <StudyApplyCard />
+          <MassageApplyCard />
         </div>
-        <div className="order-3 2xl:order-none 2xl:row-span-2">
+        <div className="order-3 2xl:order-0 2xl:row-span-2">
           <MealCard />
         </div>
-        <div className="order-1 2xl:order-none lg:col-span-2 2xl:contents">
+        <div className="order-1 2xl:order-0 lg:col-span-2 2xl:contents">
           <div className="flex flex-row gap-3 lg:gap-6 2xl:contents">
             <div className="flex-1">
               <ProfileCard user={MOCK_STUDENTS[0]} />

--- a/src/entities/dormitory/api/dormitoryHandlers.ts
+++ b/src/entities/dormitory/api/dormitoryHandlers.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { MOCK_STUDENTS } from '@/entities/user/model/mock';
-import { 
+import {
   MOCK_MY_PENALTY, 
   MOCK_ALL_PENALTIES, 
   MOCK_CLEANING_ZONES, 
@@ -9,37 +8,17 @@ import {
 
 export const dormitoryHandlers = [
   // GET — 목록 조회
-  http.get('*/dormitory/massage', () =>
-    HttpResponse.json(MOCK_STUDENTS.slice(0, 5))
-  ),
-  http.get('*/dormitory/study', () => HttpResponse.json(MOCK_STUDENTS)),
   http.get('*/dormitory/penalties/me', () => HttpResponse.json(MOCK_MY_PENALTY)),
   http.get('*/dormitory/penalties', () => HttpResponse.json(MOCK_ALL_PENALTIES)),
   http.get('*/dormitory/cleaning-zones', () => HttpResponse.json(MOCK_CLEANING_ZONES)),
   http.get('*/dormitory/cleaning-zones/:zoneId', () => HttpResponse.json(MOCK_CLEANING_ZONE_DETAIL)),
 
   // POST — 신청
-  // 구체적인 경로를 동적 경로보다 앞에 등록
-  http.post('*/dormitory/massage', () =>
-    HttpResponse.json({ success: true }, { status: 201 })
-  ),
-  http.post('*/dormitory/study', () =>
-    HttpResponse.json({ success: true }, { status: 201 })
-  ),
   http.post('*/dormitory/inquiry', () =>
     HttpResponse.json({ success: true }, { status: 201 })
   ),
   http.post('*/dormitory/cleaning-zones', () =>
     HttpResponse.json({ success: true }, { status: 201 })
-  ),
-
-  // DELETE — 취소/삭제 (구체적인 경로 먼저)
-  http.delete('*/dormitory/massage', () => new HttpResponse(null, { status: 204 })),
-  http.delete('*/dormitory/study', () => new HttpResponse(null, { status: 204 })),
-
-  // PATCH — 자습 금지
-  http.patch('*/dormitory/study/:userId', () =>
-    new HttpResponse(null, { status: 204 })
   ),
 
   // PUT — 벌점 설정

--- a/src/entities/dormitory/api/dormitoryQueries.ts
+++ b/src/entities/dormitory/api/dormitoryQueries.ts
@@ -72,19 +72,19 @@ export const dormitoryMutations = {
   deleteMusic: (musicId: number) =>
     instance.delete(`/dormitory/music/${musicId}`),
 
-  applyMassage: () => instance.post('/dormitory/massage'),
+  applyMassage: () => instance.post('/dormitory/massages'),
 
-  cancelMassage: () => instance.delete('/dormitory/massage'),
+  cancelMassage: () => instance.delete('/dormitory/massages'),
 
-  applyStudy: () => instance.post('/dormitory/study'),
+  applyStudy: () => instance.post('/dormitory/studies'),
 
-  cancelStudy: () => instance.delete('/dormitory/study'),
+  cancelStudy: () => instance.delete('/dormitory/studies'),
 
   submitInquiry: (body: { content: string }) =>
     instance.post('/dormitory/inquiry', body),
 
   banStudy: (userId: number) =>
-    instance.patch(`/dormitory/study/${userId}`),
+    instance.post(`/dormitory/studies/ban/${userId}`),
 
   updatePenalties: (userId: number, body: UpdatePenaltyRequest) => 
     instance.put(`/dormitory/penalties/${userId}`, body),

--- a/src/entities/dormitory/api/getDormitory.ts
+++ b/src/entities/dormitory/api/getDormitory.ts
@@ -8,6 +8,10 @@ import type {
   CleaningZoneDetail 
 } from '@/entities/dormitory/model/dormitory';
 
+function extractList<T>(response: T[] | { data?: T[] }): T[] {
+  return Array.isArray(response) ? response : (response.data ?? []);
+}
+
 type DormitoryMusicResponseItem = Omit<DormitoryMusic, "isLiked"> & {
   isLiked?: boolean;
 };
@@ -20,9 +24,7 @@ export async function getDormitoryMusic(date?: string): Promise<DormitoryMusic[]
     params: date ? { date } : undefined,
   });
 
-  const musicList = Array.isArray(data) ? data : data.data ?? [];
-
-  return musicList.map((music) => ({
+  return extractList(data).map((music) => ({
     ...music,
     isLiked: music.isLiked ?? false,
   }));
@@ -32,12 +34,12 @@ type DormitoryStudentResponse = DormitoryStudent[] | { data?: DormitoryStudent[]
 
 export async function getMassageApplicants(): Promise<DormitoryStudent[]> {
   const { data } = await instance.get<DormitoryStudentResponse>('/dormitory/massages');
-  return Array.isArray(data) ? data : (data.data ?? []);
+  return extractList(data);
 }
 
 export async function getSelfStudyApplicants(): Promise<DormitoryStudent[]> {
   const { data } = await instance.get<DormitoryStudentResponse>('/dormitory/studies');
-  return Array.isArray(data) ? data : (data.data ?? []);
+  return extractList(data);
 }
 
 export async function getMyPenalties(): Promise<MyPenaltyResponse> {

--- a/src/entities/dormitory/api/getDormitory.ts
+++ b/src/entities/dormitory/api/getDormitory.ts
@@ -8,10 +8,6 @@ import type {
   CleaningZoneDetail 
 } from '@/entities/dormitory/model/dormitory';
 
-function extractList<T>(response: T[] | { data?: T[] }): T[] {
-  return Array.isArray(response) ? response : (response.data ?? []);
-}
-
 type DormitoryMusicResponseItem = Omit<DormitoryMusic, "isLiked"> & {
   isLiked?: boolean;
 };
@@ -24,7 +20,9 @@ export async function getDormitoryMusic(date?: string): Promise<DormitoryMusic[]
     params: date ? { date } : undefined,
   });
 
-  return extractList(data).map((music) => ({
+  const musicList = Array.isArray(data) ? data : (data.data ?? []);
+
+  return musicList.map((music) => ({
     ...music,
     isLiked: music.isLiked ?? false,
   }));
@@ -34,12 +32,12 @@ type DormitoryStudentResponse = DormitoryStudent[] | { data?: DormitoryStudent[]
 
 export async function getMassageApplicants(): Promise<DormitoryStudent[]> {
   const { data } = await instance.get<DormitoryStudentResponse>('/dormitory/massages');
-  return extractList(data);
+  return Array.isArray(data) ? data : (data.data ?? []);
 }
 
 export async function getSelfStudyApplicants(): Promise<DormitoryStudent[]> {
   const { data } = await instance.get<DormitoryStudentResponse>('/dormitory/studies');
-  return extractList(data);
+  return Array.isArray(data) ? data : (data.data ?? []);
 }
 
 export async function getMyPenalties(): Promise<MyPenaltyResponse> {

--- a/src/entities/dormitory/api/getDormitory.ts
+++ b/src/entities/dormitory/api/getDormitory.ts
@@ -28,14 +28,16 @@ export async function getDormitoryMusic(date?: string): Promise<DormitoryMusic[]
   }));
 }
 
+type DormitoryStudentResponse = DormitoryStudent[] | { data?: DormitoryStudent[] };
+
 export async function getMassageApplicants(): Promise<DormitoryStudent[]> {
-  const { data } = await instance.get<DormitoryStudent[]>('/dormitory/massage');
-  return data;
+  const { data } = await instance.get<DormitoryStudentResponse>('/dormitory/massages');
+  return Array.isArray(data) ? data : (data.data ?? []);
 }
 
 export async function getSelfStudyApplicants(): Promise<DormitoryStudent[]> {
-  const { data } = await instance.get<DormitoryStudent[]>('/dormitory/study');
-  return data;
+  const { data } = await instance.get<DormitoryStudentResponse>('/dormitory/studies');
+  return Array.isArray(data) ? data : (data.data ?? []);
 }
 
 export async function getMyPenalties(): Promise<MyPenaltyResponse> {

--- a/src/features/massage-chair/model/useApplyMassage.ts
+++ b/src/features/massage-chair/model/useApplyMassage.ts
@@ -22,7 +22,7 @@ export function useApplyMassage() {
         : undefined;
 
       if (status === HttpStatusCode.BadRequest) {
-        toast.error("마사지 신청 시간이 아닙니다.");
+        toast.error("안마의자 신청 시간이 아닙니다.");
         return;
       }
       if (status === HttpStatusCode.Conflict) {

--- a/src/features/massage-chair/model/useApplyMassage.ts
+++ b/src/features/massage-chair/model/useApplyMassage.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
+import {
+  dormitoryQueries,
+  dormitoryMutations,
+} from "@/entities/dormitory/api/dormitoryQueries";
+
+export function useApplyMassage() {
+  const queryClient = useQueryClient();
+  const massageQuery = dormitoryQueries.massage();
+
+  return useMutation({
+    mutationFn: dormitoryMutations.applyMassage,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: massageQuery.queryKey }),
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.BadRequest) {
+        toast.error("마사지 신청 시간이 아닙니다.");
+        return;
+      }
+      if (status === HttpStatusCode.Conflict) {
+        toast.error("이미 안마의자를 신청했습니다.");
+        return;
+      }
+
+      toast.error("안마의자 신청에 실패했습니다.");
+    },
+  });
+}

--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
 import Chair from "@/shared/asset/svg/Chair";
 import { ProfileCard } from "@/entities/user/ui/ProfileCard";
 import { TextButton } from "@/shared/ui/Button/TextButton";
@@ -18,6 +20,22 @@ export function MassageChairSection() {
     mutationFn: dormitoryMutations.applyMassage,
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: massageQuery.queryKey }),
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.BadRequest) {
+        toast.error("마사지 신청 시간이 아닙니다.");
+        return;
+      }
+      if (status === HttpStatusCode.Conflict) {
+        toast.error("이미 안마의자를 신청했습니다.");
+        return;
+      }
+
+      toast.error("안마의자 신청에 실패했습니다.");
+    },
   });
 
   return (

--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -1,42 +1,16 @@
 "use client";
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import axios, { HttpStatusCode } from "axios";
-import { toast } from "sonner";
+import { useQuery } from "@tanstack/react-query";
 import Chair from "@/shared/asset/svg/Chair";
 import { ProfileCard } from "@/entities/user/ui/ProfileCard";
 import { TextButton } from "@/shared/ui/Button/TextButton";
-import {
-  dormitoryQueries,
-  dormitoryMutations,
-} from "@/entities/dormitory/api/dormitoryQueries";
+import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
+import { useApplyMassage } from "../model/useApplyMassage";
 
 export function MassageChairSection() {
-  const queryClient = useQueryClient();
   const massageQuery = dormitoryQueries.massage();
   const { data: applicants = [] } = useQuery(massageQuery);
-
-  const applyMutation = useMutation({
-    mutationFn: dormitoryMutations.applyMassage,
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: massageQuery.queryKey }),
-    onError: (error) => {
-      const status = axios.isAxiosError(error)
-        ? error.response?.status
-        : undefined;
-
-      if (status === HttpStatusCode.BadRequest) {
-        toast.error("마사지 신청 시간이 아닙니다.");
-        return;
-      }
-      if (status === HttpStatusCode.Conflict) {
-        toast.error("이미 안마의자를 신청했습니다.");
-        return;
-      }
-
-      toast.error("안마의자 신청에 실패했습니다.");
-    },
-  });
+  const applyMutation = useApplyMassage();
 
   return (
     <section className="bg-background-surface rounded-2xl p-6 flex flex-col gap-6">

--- a/src/features/self-study/model/useApplyStudy.ts
+++ b/src/features/self-study/model/useApplyStudy.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
+import {
+  dormitoryQueries,
+  dormitoryMutations,
+} from "@/entities/dormitory/api/dormitoryQueries";
+
+export function useApplyStudy() {
+  const queryClient = useQueryClient();
+  const studyQuery = dormitoryQueries.study();
+
+  return useMutation({
+    mutationFn: dormitoryMutations.applyStudy,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey }),
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.BadRequest) {
+        toast.error("자습 신청 시간이 아닙니다.");
+        return;
+      }
+      if (status === HttpStatusCode.Forbidden) {
+        toast.error("자습 금지 상태입니다.");
+        return;
+      }
+      if (status === HttpStatusCode.Conflict) {
+        toast.error("이미 자습을 신청했습니다.");
+        return;
+      }
+
+      toast.error("자습 신청에 실패했습니다.");
+    },
+  });
+}

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
 import ApplyStudy from "@/shared/asset/svg/ApplyStudy";
 import Search from "@/shared/asset/svg/Search";
 import { ProfileCard } from "@/entities/user/ui/ProfileCard";
@@ -28,6 +30,26 @@ export function SelfStudySection() {
     mutationFn: dormitoryMutations.applyStudy,
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: studyQuery.queryKey }),
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.BadRequest) {
+        toast.error("자습 신청 시간이 아닙니다.");
+        return;
+      }
+      if (status === HttpStatusCode.Forbidden) {
+        toast.error("자습 금지 상태입니다.");
+        return;
+      }
+      if (status === HttpStatusCode.Conflict) {
+        toast.error("이미 자습을 신청했습니다.");
+        return;
+      }
+
+      toast.error("자습 신청에 실패했습니다.");
+    },
   });
 
   const handleResetFilters = () => dispatch({ type: "RESET" });

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -1,56 +1,26 @@
 "use client";
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import axios, { HttpStatusCode } from "axios";
-import { toast } from "sonner";
+import { useQuery } from "@tanstack/react-query";
 import ApplyStudy from "@/shared/asset/svg/ApplyStudy";
 import Search from "@/shared/asset/svg/Search";
 import { ProfileCard } from "@/entities/user/ui/ProfileCard";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import { NumberButton } from "@/shared/ui/Button/NumberButton";
 import TextField from "@/shared/ui/textField";
-import {
-  dormitoryQueries,
-  dormitoryMutations,
-} from "@/entities/dormitory/api/dormitoryQueries";
+import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
 import { useStudyFilter } from "../model/useStudyFilter";
+import { useApplyStudy } from "../model/useApplyStudy";
 
 const GRADE_OPTIONS = [1, 2, 3] as const;
 const CLASS_OPTIONS = [1, 2, 3, 4] as const;
 
 export function SelfStudySection() {
-  const queryClient = useQueryClient();
   const studyQuery = dormitoryQueries.study();
   const { data: students = [] } = useQuery(studyQuery);
   const { state, filteredStudents, dispatch } = useStudyFilter(students);
   const { searchQuery, selectedGrades, selectedClasses, selectedGender } =
     state;
-
-  const applyMutation = useMutation({
-    mutationFn: dormitoryMutations.applyStudy,
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey }),
-    onError: (error) => {
-      const status = axios.isAxiosError(error)
-        ? error.response?.status
-        : undefined;
-
-      if (status === HttpStatusCode.BadRequest) {
-        toast.error("자습 신청 시간이 아닙니다.");
-        return;
-      }
-      if (status === HttpStatusCode.Forbidden) {
-        toast.error("자습 금지 상태입니다.");
-        return;
-      }
-      if (status === HttpStatusCode.Conflict) {
-        toast.error("이미 자습을 신청했습니다.");
-        return;
-      }
-
-      toast.error("자습 신청에 실패했습니다.");
-    },
-  });
+  const applyMutation = useApplyStudy();
 
   const handleResetFilters = () => dispatch({ type: "RESET" });
   const handleSearchQueryChange = (value: string) =>

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -1,4 +1,5 @@
-import axios from "axios";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
 
 export const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -32,6 +33,15 @@ if (typeof window !== "undefined") {
     (response) => response,
     async (error) => {
       const originalRequest = error.config;
+
+      if (
+        error.response?.status === HttpStatusCode.Forbidden &&
+        !sessionStorage.getItem("access_token")
+      ) {
+        toast.error("로그인이 필요합니다.");
+        window.location.href = "/signin";
+        return Promise.reject(error);
+      }
 
       if (
         error.response?.status === 401 &&

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -34,13 +34,17 @@ if (typeof window !== "undefined") {
     async (error) => {
       const originalRequest = error.config;
 
-      if (
-        error.response?.status === HttpStatusCode.Forbidden &&
-        !sessionStorage.getItem("access_token")
-      ) {
-        toast.error("로그인이 필요합니다.");
-        window.location.href = "/signin";
-        return Promise.reject(error);
+      if (error.response?.status === HttpStatusCode.Forbidden) {
+        const isGetRequest = originalRequest.method?.toUpperCase() === "GET";
+        const hasToken = !!sessionStorage.getItem("access_token");
+
+        if (isGetRequest || !hasToken) {
+          sessionStorage.removeItem("access_token");
+          sessionStorage.removeItem("user");
+          toast.error("로그인이 필요합니다.");
+          window.location.href = "/signin";
+          return Promise.reject(error);
+        }
       }
 
       if (

--- a/src/widgets/main/ui/ApplyCard.tsx
+++ b/src/widgets/main/ui/ApplyCard.tsx
@@ -24,6 +24,8 @@ export default function ApplyCard({
   femaleNotice = false,
   onApply,
 }: ApplyCardProps) {
+  const isApplyEnabled = !disabled;
+
   return (
     <div className="w-full bg-background-surface rounded-2xl p-6">
       <div className="flex items-start justify-between mb-3">
@@ -65,9 +67,10 @@ export default function ApplyCard({
           )}
         </div>
         <TextButton
-          variant={disabled ? "disabled" : "filled"}
+          variant={isApplyEnabled ? "filled" : "disabled"}
           size="small"
-          onClick={onApply}
+          disabled={!isApplyEnabled}
+          onClick={isApplyEnabled ? onApply : undefined}
         >
           {buttonText}
         </TextButton>

--- a/src/widgets/main/ui/ApplyCard.tsx
+++ b/src/widgets/main/ui/ApplyCard.tsx
@@ -10,6 +10,7 @@ interface ApplyCardProps {
   buttonText: string;
   disabled?: boolean;
   femaleNotice?: boolean;
+  onApply?: () => void;
 }
 
 export default function ApplyCard({
@@ -21,6 +22,7 @@ export default function ApplyCard({
   buttonText,
   disabled = false,
   femaleNotice = false,
+  onApply,
 }: ApplyCardProps) {
   return (
     <div className="w-full bg-background-surface rounded-2xl p-6">
@@ -62,7 +64,11 @@ export default function ApplyCard({
             </p>
           )}
         </div>
-        <TextButton variant={disabled ? "disabled" : "filled"} size="small">
+        <TextButton
+          variant={disabled ? "disabled" : "filled"}
+          size="small"
+          onClick={onApply}
+        >
           {buttonText}
         </TextButton>
       </div>

--- a/src/widgets/main/ui/MassageApplyCard.tsx
+++ b/src/widgets/main/ui/MassageApplyCard.tsx
@@ -1,43 +1,17 @@
 "use client";
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import axios, { HttpStatusCode } from "axios";
-import { toast } from "sonner";
+import { useQuery } from "@tanstack/react-query";
 import ChairIcon from "@/shared/asset/svg/Chair";
+import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
+import { useApplyMassage } from "@/features/massage-chair/model/useApplyMassage";
 import ApplyCard from "./ApplyCard";
-import {
-  dormitoryQueries,
-  dormitoryMutations,
-} from "@/entities/dormitory/api/dormitoryQueries";
 
 const MASSAGE_MAX = 5;
 
 export default function MassageApplyCard() {
-  const queryClient = useQueryClient();
   const massageQuery = dormitoryQueries.massage();
   const { data: applicants = [] } = useQuery(massageQuery);
-
-  const applyMutation = useMutation({
-    mutationFn: dormitoryMutations.applyMassage,
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: massageQuery.queryKey }),
-    onError: (error) => {
-      const status = axios.isAxiosError(error)
-        ? error.response?.status
-        : undefined;
-
-      if (status === HttpStatusCode.BadRequest) {
-        toast.error("마사지 신청 시간이 아닙니다.");
-        return;
-      }
-      if (status === HttpStatusCode.Conflict) {
-        toast.error("이미 안마의자를 신청했습니다.");
-        return;
-      }
-
-      toast.error("안마의자 신청에 실패했습니다.");
-    },
-  });
+  const applyMutation = useApplyMassage();
 
   return (
     <ApplyCard

--- a/src/widgets/main/ui/MassageApplyCard.tsx
+++ b/src/widgets/main/ui/MassageApplyCard.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
+import ChairIcon from "@/shared/asset/svg/Chair";
+import ApplyCard from "./ApplyCard";
+import {
+  dormitoryQueries,
+  dormitoryMutations,
+} from "@/entities/dormitory/api/dormitoryQueries";
+
+const MASSAGE_MAX = 5;
+
+export default function MassageApplyCard() {
+  const queryClient = useQueryClient();
+  const massageQuery = dormitoryQueries.massage();
+  const { data: applicants = [] } = useQuery(massageQuery);
+
+  const applyMutation = useMutation({
+    mutationFn: dormitoryMutations.applyMassage,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: massageQuery.queryKey }),
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.BadRequest) {
+        toast.error("마사지 신청 시간이 아닙니다.");
+        return;
+      }
+      if (status === HttpStatusCode.Conflict) {
+        toast.error("이미 안마의자를 신청했습니다.");
+        return;
+      }
+
+      toast.error("안마의자 신청에 실패했습니다.");
+    },
+  });
+
+  return (
+    <ApplyCard
+      title="안마의자"
+      icon={<ChairIcon />}
+      current={applicants.length}
+      total={MASSAGE_MAX}
+      timeText="안마 의자 신청 시간은 20:20 ~ 21:00에 신청이 가능해요"
+      buttonText="신청"
+      femaleNotice
+      onApply={() => applyMutation.mutate()}
+    />
+  );
+}

--- a/src/widgets/main/ui/StudyApplyCard.tsx
+++ b/src/widgets/main/ui/StudyApplyCard.tsx
@@ -1,47 +1,17 @@
 "use client";
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import axios, { HttpStatusCode } from "axios";
-import { toast } from "sonner";
+import { useQuery } from "@tanstack/react-query";
 import BookIcon from "@/shared/asset/svg/ApplyStudy";
+import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
+import { useApplyStudy } from "@/features/self-study/model/useApplyStudy";
 import ApplyCard from "./ApplyCard";
-import {
-  dormitoryQueries,
-  dormitoryMutations,
-} from "@/entities/dormitory/api/dormitoryQueries";
 
 const STUDY_MAX = 50;
 
 export default function StudyApplyCard() {
-  const queryClient = useQueryClient();
   const studyQuery = dormitoryQueries.study();
   const { data: students = [] } = useQuery(studyQuery);
-
-  const applyMutation = useMutation({
-    mutationFn: dormitoryMutations.applyStudy,
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey }),
-    onError: (error) => {
-      const status = axios.isAxiosError(error)
-        ? error.response?.status
-        : undefined;
-
-      if (status === HttpStatusCode.BadRequest) {
-        toast.error("자습 신청 시간이 아닙니다.");
-        return;
-      }
-      if (status === HttpStatusCode.Forbidden) {
-        toast.error("자습 금지 상태입니다.");
-        return;
-      }
-      if (status === HttpStatusCode.Conflict) {
-        toast.error("이미 자습을 신청했습니다.");
-        return;
-      }
-
-      toast.error("자습 신청에 실패했습니다.");
-    },
-  });
+  const applyMutation = useApplyStudy();
 
   return (
     <ApplyCard

--- a/src/widgets/main/ui/StudyApplyCard.tsx
+++ b/src/widgets/main/ui/StudyApplyCard.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
+import BookIcon from "@/shared/asset/svg/ApplyStudy";
+import ApplyCard from "./ApplyCard";
+import {
+  dormitoryQueries,
+  dormitoryMutations,
+} from "@/entities/dormitory/api/dormitoryQueries";
+
+const STUDY_MAX = 50;
+
+export default function StudyApplyCard() {
+  const queryClient = useQueryClient();
+  const studyQuery = dormitoryQueries.study();
+  const { data: students = [] } = useQuery(studyQuery);
+
+  const applyMutation = useMutation({
+    mutationFn: dormitoryMutations.applyStudy,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey }),
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.BadRequest) {
+        toast.error("자습 신청 시간이 아닙니다.");
+        return;
+      }
+      if (status === HttpStatusCode.Forbidden) {
+        toast.error("자습 금지 상태입니다.");
+        return;
+      }
+      if (status === HttpStatusCode.Conflict) {
+        toast.error("이미 자습을 신청했습니다.");
+        return;
+      }
+
+      toast.error("자습 신청에 실패했습니다.");
+    },
+  });
+
+  return (
+    <ApplyCard
+      title="자습신청"
+      icon={<BookIcon />}
+      current={students.length}
+      total={STUDY_MAX}
+      timeText="자습 신청 시간은 20:00 ~ 21:00에 신청이 가능해요"
+      buttonText="신청"
+      onApply={() => applyMutation.mutate()}
+    />
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#49 #57

## 📝작업 내용

안마의자·자습 신청 기능을 실제 API에 연동하고, 신청 시 발생할 수 있는 오류 상황에 대한 토스트 에러 처리를 추가했습니다.

### API 연동

- 응답 타입을 배열·래핑 객체 양쪽 모두 처리하도록 보완 (`DormitoryStudentResponse` 유니온 타입)
- MSW 핸들러에서 안마의자·자습 관련 mock 제거 (실제 API 사용)

### UI 연결 (widgets/main)

- `ApplyCard`에 `onApply` prop 추가, 버튼 `onClick`에 연결
- `StudyApplyCard` / `MassageApplyCard` 컴포넌트 추가, 신청 인원 조회 및 신청 mutation 처리
- 메인 페이지(`app/(main)/page.tsx`)의 하드코딩된 `ApplyCard`를 실제 API 연동 컴포넌트로 교체

### 에러 처리

- `MassageChairSection` / `SelfStudySection` / `MassageApplyCard` / `StudyApplyCard` 에러 토스트
   - 안마의자: `400` 신청 시간 외, `409` 중복 신청
   - 자습: `400` 신청 시간 외, `403` 자습 금지, `409` 중복 신청
- `shared/api/instance.ts` — 응답 인터셉터에 전역 `403` 처리 추가: 액세스 토큰 없이 403이 반환되면 로그인 페이지로 리다이렉트

## 💬리뷰 요구사항(선택)

- 전역 403 인터셉터에서 `sessionStorage`에 토큰이 없을 때만 리다이렉트하도록 처리했는데, 토큰이 있는 상태의 403(자습 금지)은 각 컴포넌트 `onError`에서 처리합니다. 이 구분 방식이 적절한지 의견 주시면 감사하겠습니다.