### PR TITLE
feat: 클럽 멤버 초대·추방 및 학생 관리 기능 추가

### DIFF
--- a/src/entities/club/api/clubHandlers.ts
+++ b/src/entities/club/api/clubHandlers.ts
@@ -205,6 +205,54 @@ export const clubHandlers = [
     }),
   ),
 
+  http.post('*/clubs/:clubId/member/:userId', ({ params }) => {
+    const clubId = Number(params.clubId);
+    const userId = Number(params.userId);
+    const detail = MOCK_CLUB_DETAILS[clubId];
+
+    if (!detail) {
+      return HttpResponse.json(
+        { status: 'NOT_FOUND', code: 404, message: '동아리 없음' },
+        { status: 404 },
+      );
+    }
+
+    const alreadyMember = detail.members.some((m) => m.id === userId);
+    if (alreadyMember) {
+      return HttpResponse.json(
+        { status: 'CONFLICT', code: 409, message: '이미 멤버입니다.' },
+        { status: 409 },
+      );
+    }
+
+    return HttpResponse.json({
+      status: 'OK',
+      code: 200,
+      message: 'OK',
+    });
+  }),
+
+  http.delete('*/clubs/:clubId/member/exile/:userId', ({ params }) => {
+    const clubId = Number(params.clubId);
+    const userId = Number(params.userId);
+    const detail = MOCK_CLUB_DETAILS[clubId];
+
+    if (!detail) {
+      return HttpResponse.json(
+        { status: 'NOT_FOUND', code: 404, message: '동아리 없음' },
+        { status: 404 },
+      );
+    }
+
+    detail.members = detail.members.filter((m) => m.id !== userId);
+
+    return HttpResponse.json({
+      status: 'OK',
+      code: 200,
+      message: 'OK',
+    });
+  }),
+
   http.patch('*/clubs/:id/transfer/:targetUserId', ({ params }) => {
     const id = Number(params.id);
     const targetUserId = Number(params.targetUserId);

--- a/src/entities/club/api/clubHandlers.ts
+++ b/src/entities/club/api/clubHandlers.ts
@@ -5,6 +5,7 @@ import {
   MOCK_CLUB_DETAILS,
   MOCK_CLUB_FORMS,
 } from '../model/mock';
+import { MOCK_STUDENTS } from '@/entities/user/model/mock';
 import type { CreateClubFormRequest } from '../model/club';
 
 const MAJOR_CLUBS = MOCK_CLUBS.filter((c) => c.type === 'MAJOR_CLUB');
@@ -224,6 +225,22 @@ export const clubHandlers = [
         { status: 409 },
       );
     }
+
+    const student = MOCK_STUDENTS.find((s) => s.id === userId);
+    if (!student) {
+      return HttpResponse.json(
+        { status: 'NOT_FOUND', code: 404, message: '유저를 찾을 수 없습니다.' },
+        { status: 404 },
+      );
+    }
+
+    detail.members.push({
+      id: student.id,
+      name: student.name,
+      studentNumber: student.studentNumber,
+      sex: student.sex,
+      specialty: student.specialty,
+    });
 
     return HttpResponse.json({
       status: 'OK',

--- a/src/entities/club/api/clubQueries.ts
+++ b/src/entities/club/api/clubQueries.ts
@@ -53,4 +53,10 @@ export const clubMutations = {
 
   transferLeader: (clubId: number, targetUserId: number) =>
     instance.patch(`/clubs/${clubId}/transfer/${targetUserId}`),
+
+  inviteMember: (clubId: number, userId: number) =>
+    instance.post(`/clubs/${clubId}/member/${userId}`),
+
+  exileMember: (clubId: number, userId: number) =>
+    instance.delete(`/clubs/${clubId}/member/exile/${userId}`),
 } as const;

--- a/src/entities/club/model/club.ts
+++ b/src/entities/club/model/club.ts
@@ -21,6 +21,7 @@ export interface ClubDetail {
   name: string;
   type: ClubType;
   leader?: string;
+  leaderId?: number;
   description: string;
   imageUrl?: string;
   maxMember?: number;

--- a/src/entities/club/model/club.ts
+++ b/src/entities/club/model/club.ts
@@ -21,7 +21,6 @@ export interface ClubDetail {
   name: string;
   type: ClubType;
   leader?: string;
-  leaderId?: number;
   description: string;
   imageUrl?: string;
   maxMember?: number;

--- a/src/entities/club/model/mock.ts
+++ b/src/entities/club/model/mock.ts
@@ -79,6 +79,7 @@ export const MOCK_CLUB_DETAILS: Record<number, ClubDetailResponse> = {
       name: '인력사무소',
       type: 'MAJOR_CLUB',
       leader: '김민솔',
+      leaderId: 1,
       description: '조보기능/프론트 노동기능을 갖춘 선후배 팀원이 함께하는 개발 동아리',
       imageUrl: undefined,
       maxMember: 30,

--- a/src/entities/club/model/mock.ts
+++ b/src/entities/club/model/mock.ts
@@ -79,7 +79,6 @@ export const MOCK_CLUB_DETAILS: Record<number, ClubDetailResponse> = {
       name: '인력사무소',
       type: 'MAJOR_CLUB',
       leader: '김민솔',
-      leaderId: 1,
       description: '조보기능/프론트 노동기능을 갖춘 선후배 팀원이 함께하는 개발 동아리',
       imageUrl: undefined,
       maxMember: 30,

--- a/src/entities/club/ui/ClubDetail.tsx
+++ b/src/entities/club/ui/ClubDetail.tsx
@@ -53,7 +53,9 @@ export default function ClubDetail({
 
   const { club, members, projects } = detail;
   const applyVariant = isApplyPending || !onApplyClick ? "disabled" : "filled";
-  const nonLeaderMembers = members.filter((m) => m.name !== club.leader);
+  const nonLeaderMembers = members.filter((m) =>
+    club.leaderId !== undefined ? m.id !== club.leaderId : m.name !== club.leader
+  );
 
   const handleEditClick = () => {
     setIsEditMode((prev) => !prev);
@@ -94,6 +96,7 @@ export default function ClubDetail({
         <ClubMemberList
           members={members}
           leader={club.leader}
+          leaderId={club.leaderId}
           isLeader={isLeader}
           onMemberClick={onTransferClick}
         />

--- a/src/entities/club/ui/ClubDetail.tsx
+++ b/src/entities/club/ui/ClubDetail.tsx
@@ -12,7 +12,7 @@ import type {
   ClubDetailResponse as ClubDetailType,
   ClubMember,
 } from "../model/club";
-import type { User } from "@/entities/user/model/user";
+import type { SearchUser } from "@/entities/user/model/user";
 import ProjectCard from "./ProjectCard";
 import ClubMemberList from "./ClubMemberList";
 
@@ -26,9 +26,9 @@ interface ClubDetailProps {
   onTransferClick?: (member: ClubMember) => void;
   onEditClick?: () => void;
   memberSearchQuery?: string;
-  memberSearchResults?: User[];
+  memberSearchResults?: SearchUser[];
   onMemberSearchChange?: (query: string) => void;
-  onMemberInvite?: (user: User) => void;
+  onMemberInvite?: (user: SearchUser) => void;
   onMemberExile?: (memberId: number) => void;
   formActionLabel?: string;
 }
@@ -53,9 +53,7 @@ export default function ClubDetail({
 
   const { club, members, projects } = detail;
   const applyVariant = isApplyPending || !onApplyClick ? "disabled" : "filled";
-  const nonLeaderMembers = members.filter((m) =>
-    club.leaderId !== undefined ? m.id !== club.leaderId : m.name !== club.leader
-  );
+  const nonLeaderMembers = members.filter((m) => m.name !== club.leader);
 
   const handleEditClick = () => {
     setIsEditMode((prev) => !prev);
@@ -96,7 +94,6 @@ export default function ClubDetail({
         <ClubMemberList
           members={members}
           leader={club.leader}
-          leaderId={club.leaderId}
           isLeader={isLeader}
           onMemberClick={onTransferClick}
         />

--- a/src/entities/club/ui/ClubDetail.tsx
+++ b/src/entities/club/ui/ClubDetail.tsx
@@ -1,7 +1,18 @@
+"use client";
+
+import { useState } from "react";
 import Image from "next/image";
 import DefaultClubThumbnail from "@/shared/asset/svg/DefaultThumbnail";
 import { TextButton } from "@/shared/ui/Button/TextButton";
-import type { ClubDetailResponse as ClubDetailType, ClubMember } from "../model/club";
+import TextField from "@/shared/ui/textField";
+import Search from "@/shared/asset/svg/Search";
+import Edit from "@/shared/asset/svg/Edit";
+import Cancel from "@/shared/asset/svg/Cancel";
+import type {
+  ClubDetailResponse as ClubDetailType,
+  ClubMember,
+} from "../model/club";
+import type { User } from "@/entities/user/model/user";
 import ProjectCard from "./ProjectCard";
 import ClubMemberList from "./ClubMemberList";
 
@@ -13,6 +24,12 @@ interface ClubDetailProps {
   onViewApplicationsClick?: () => void;
   onCreateFormClick?: () => void;
   onTransferClick?: (member: ClubMember) => void;
+  onEditClick?: () => void;
+  memberSearchQuery?: string;
+  memberSearchResults?: User[];
+  onMemberSearchChange?: (query: string) => void;
+  onMemberInvite?: (user: User) => void;
+  onMemberExile?: (memberId: number) => void;
   formActionLabel?: string;
 }
 
@@ -24,10 +41,24 @@ export default function ClubDetail({
   onViewApplicationsClick,
   onCreateFormClick,
   onTransferClick,
+  onEditClick,
+  memberSearchQuery = "",
+  memberSearchResults = [],
+  onMemberSearchChange,
+  onMemberInvite,
+  onMemberExile,
   formActionLabel = "폼 만들기",
 }: ClubDetailProps) {
+  const [isEditMode, setIsEditMode] = useState(false);
+
   const { club, members, projects } = detail;
   const applyVariant = isApplyPending || !onApplyClick ? "disabled" : "filled";
+  const nonLeaderMembers = members.filter((m) => m.name !== club.leader);
+
+  const handleEditClick = () => {
+    setIsEditMode((prev) => !prev);
+    onEditClick?.();
+  };
 
   return (
     <div className="flex w-full flex-col gap-6 xl:flex-row">
@@ -66,6 +97,63 @@ export default function ClubDetail({
           isLeader={isLeader}
           onMemberClick={onTransferClick}
         />
+
+        {isLeader && isEditMode && (
+          <div className="flex flex-col gap-3">
+            <span className="2xl:text-title-4 lg:text-text-1 text-main-text">
+              부원 추가
+            </span>
+            <div className="relative">
+              <TextField
+                value={memberSearchQuery}
+                onChange={(e) => onMemberSearchChange?.(e.target.value)}
+                placeholder="이름, 학번을 입력해주세요"
+                rightIcon={<Search />}
+              />
+              {memberSearchResults.length > 0 && memberSearchQuery.trim() && (
+                <div className="absolute z-10 w-full mt-1 border border-sub-4 rounded-lg overflow-hidden bg-background-surface shadow-md">
+                  <div className="flex flex-col divide-y divide-sub-4 px-2">
+                    {memberSearchResults.map((user) => (
+                      <button
+                        key={user.id}
+                        type="button"
+                        onClick={() => onMemberInvite?.(user)}
+                        className="w-full text-left py-3 px-2 text-text-2 text-main-text hover:bg-sub-4 transition-colors"
+                      >
+                        {user.studentNumber} {user.name}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {nonLeaderMembers.length > 0 && (
+              <div className="grid grid-cols-3 gap-2">
+                {nonLeaderMembers.map((member) => (
+                  <div
+                    key={member.id}
+                    className="flex items-center justify-center gap-1.5 lg:gap-2 px-3 py-1.5 lg:px-4 lg:py-2 2xl:px-6 2xl:py-3 rounded-[38px] border border-sub-2 bg-background-surface text-caption-1 2xl:text-text-2 text-main-text"
+                  >
+                    <span className="whitespace-nowrap">
+                      {member.studentNumber} {member.name}
+                    </span>
+                    {onMemberExile && (
+                      <button
+                        type="button"
+                        onClick={() => onMemberExile(member.id)}
+                        className="shrink-0 flex items-center [&>svg]:w-3 [&>svg]:h-3 2xl:[&>svg]:w-3.5 2xl:[&>svg]:h-3.5 text-sub-2 hover:text-negative transition-colors"
+                        aria-label={`${member.name} 추방`}
+                      >
+                        <Cancel />
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="flex min-w-0 flex-1 flex-col gap-4 xl:self-stretch">
@@ -85,6 +173,18 @@ export default function ClubDetail({
         </div>
 
         <div className="flex flex-wrap justify-end gap-2">
+          {isLeader && onEditClick && (
+            <button
+              type="button"
+              onClick={handleEditClick}
+              className={`flex items-center justify-center w-11.75 h-11.75 rounded-xl transition-colors ${
+                isEditMode ? "bg-sub-3" : "bg-sub-4 hover:bg-sub-3"
+              }`}
+              aria-label="동아리 수정"
+            >
+              <Edit />
+            </button>
+          )}
           {onViewApplicationsClick && (
             <TextButton
               size="medium"

--- a/src/entities/club/ui/ClubDetail.tsx
+++ b/src/entities/club/ui/ClubDetail.tsx
@@ -53,7 +53,9 @@ export default function ClubDetail({
 
   const { club, members, projects } = detail;
   const applyVariant = isApplyPending || !onApplyClick ? "disabled" : "filled";
-  const nonLeaderMembers = members.filter((m) => m.name !== club.leader);
+  const nonLeaderMembers = members.filter((m) =>
+    club.leaderId !== undefined ? m.id !== club.leaderId : m.name !== club.leader
+  );
 
   const handleEditClick = () => {
     setIsEditMode((prev) => !prev);
@@ -94,6 +96,7 @@ export default function ClubDetail({
         <ClubMemberList
           members={members}
           leader={club.leader}
+          leaderId={club.leaderId}
           isLeader={isLeader}
           onMemberClick={onTransferClick}
         />
@@ -189,7 +192,7 @@ export default function ClubDetail({
             <TextButton
               size="medium"
               variant="outlined"
-              className="h-[47px] w-auto min-w-[147px] px-4"
+              className="h-11.75 w-auto min-w-36.75 px-4"
               onClick={onViewApplicationsClick}
             >
               신청자 목록
@@ -199,7 +202,7 @@ export default function ClubDetail({
             <TextButton
               size="medium"
               variant="outlined"
-              className="h-[47px]"
+              className="h-11.75"
               onClick={onCreateFormClick}
             >
               {formActionLabel}

--- a/src/entities/club/ui/ClubMemberList.tsx
+++ b/src/entities/club/ui/ClubMemberList.tsx
@@ -5,6 +5,7 @@ import { getSortedGrades } from "../lib/getSortedGrades";
 interface ClubMemberListProps {
   members: ClubMember[];
   leader?: string;
+  leaderId?: number;
   isLeader?: boolean;
   onMemberClick?: (member: ClubMember) => void;
 }
@@ -12,6 +13,7 @@ interface ClubMemberListProps {
 export default function ClubMemberList({
   members,
   leader,
+  leaderId,
   isLeader = false,
   onMemberClick,
 }: ClubMemberListProps) {
@@ -32,7 +34,7 @@ export default function ClubMemberList({
             <div key={grade} className="text-text-1">
               <span className="text-sub-1">{grade}학년 - </span>
               {gradeMembers.map((m, i) => {
-                const isCurrentLeader = m.name === leader;
+                const isCurrentLeader = leaderId !== undefined ? m.id === leaderId : m.name === leader;
                 const isClickable =
                   isLeader && !isCurrentLeader && !!onMemberClick;
                 return (

--- a/src/entities/club/ui/ClubMemberList.tsx
+++ b/src/entities/club/ui/ClubMemberList.tsx
@@ -5,7 +5,6 @@ import { getSortedGrades } from "../lib/getSortedGrades";
 interface ClubMemberListProps {
   members: ClubMember[];
   leader?: string;
-  leaderId?: number;
   isLeader?: boolean;
   onMemberClick?: (member: ClubMember) => void;
 }
@@ -13,7 +12,6 @@ interface ClubMemberListProps {
 export default function ClubMemberList({
   members,
   leader,
-  leaderId,
   isLeader = false,
   onMemberClick,
 }: ClubMemberListProps) {
@@ -34,7 +32,7 @@ export default function ClubMemberList({
             <div key={grade} className="text-text-1">
               <span className="text-sub-1">{grade}학년 - </span>
               {gradeMembers.map((m, i) => {
-                const isCurrentLeader = leaderId !== undefined ? m.id === leaderId : m.name === leader;
+                const isCurrentLeader = m.name === leader;
                 const isClickable =
                   isLeader && !isCurrentLeader && !!onMemberClick;
                 return (

--- a/src/entities/user/api/userHandlers.ts
+++ b/src/entities/user/api/userHandlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw';
-import type { User } from '../model/user';
+import type { User, SearchUser, SearchUsersPage } from '../model/user';
+import { MOCK_STUDENTS } from '../model/mock';
 
 // 테스트용 mock 유저 — 인력사무소(id: 1) 부장
 // 실제 인증 연동 후 제거 예정
@@ -23,5 +24,39 @@ const MOCK_ME: User = {
 export const userHandlers = [
   http.get('*/users/me', () => {
     return HttpResponse.json({ data: MOCK_ME });
+  }),
+  http.get('*/users', ({ request }) => {
+    const url = new URL(request.url);
+    const name = url.searchParams.get('name');
+    const studentNumber = url.searchParams.get('studentNumber');
+    const page = parseInt(url.searchParams.get('page') ?? '0', 10);
+    const size = parseInt(url.searchParams.get('size') ?? '500', 10);
+
+    const filtered: SearchUser[] = MOCK_STUDENTS
+      .filter((s) => {
+        if (name && !s.name.includes(name)) return false;
+        if (studentNumber && !String(s.studentNumber).includes(studentNumber)) return false;
+        return true;
+      })
+      .map(({ id, name: sName, sex, studentNumber: sNum, grade, classNumber, number, isBanned }) => ({
+        id, name: sName, sex, studentNumber: sNum, grade, classNumber, number, isBanned,
+      }));
+
+    const start = page * size;
+    const content = filtered.slice(start, start + size);
+
+    const result: SearchUsersPage = {
+      content,
+      totalElements: filtered.length,
+      totalPages: Math.ceil(filtered.length / size),
+      numberOfElements: content.length,
+      size,
+      number: page,
+      first: page === 0,
+      last: start + size >= filtered.length,
+      empty: content.length === 0,
+    };
+
+    return HttpResponse.json({ data: result });
   }),
 ];

--- a/src/features/club/model/useExileClubMember.ts
+++ b/src/features/club/model/useExileClubMember.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { clubMutations } from "@/entities/club/api/clubQueries";
+
+export function useExileClubMember(clubId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) => clubMutations.exileMember(clubId, userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["club", "detail", clubId] });
+      toast.success("멤버를 추방했습니다.");
+    },
+    onError: () => {
+      toast.error("멤버 추방에 실패했습니다.");
+    },
+  });
+}

--- a/src/features/club/model/useInviteClubMember.ts
+++ b/src/features/club/model/useInviteClubMember.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { clubMutations } from "@/entities/club/api/clubQueries";
+
+export function useInviteClubMember(clubId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) => clubMutations.inviteMember(clubId, userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["club", "detail", clubId] });
+      toast.success("멤버를 초대했습니다.");
+    },
+    onError: () => {
+      toast.error("멤버 초대에 실패했습니다.");
+    },
+  });
+}

--- a/src/features/club/ui/ClubDetailSection.tsx
+++ b/src/features/club/ui/ClubDetailSection.tsx
@@ -8,13 +8,35 @@ import Club from "@/shared/asset/svg/Club";
 import ClubDetail from "@/entities/club/ui/ClubDetail";
 import { clubQueries } from "@/entities/club/api/clubQueries";
 import { userQueries } from "@/entities/user/api/userQueries";
+import { MOCK_STUDENTS } from "@/entities/user/model/mock";
 import type { ClubMember } from "@/entities/club/model/club";
+import type { User } from "@/entities/user/model/user";
 import { useApplyAutonomousClub } from "../model/useApplyAutonomousClub";
 import { useTransferClubLeader } from "../model/useTransferClubLeader";
+import { useInviteClubMember } from "../model/useInviteClubMember";
+import { useExileClubMember } from "../model/useExileClubMember";
 import { ClubTransferModal } from "./ClubTransferModal";
 
 interface ClubDetailSectionProps {
   id: number;
+}
+
+const SEARCH_RESULT_LIMIT = 5;
+
+function filterSearchResults(query: string, members: ClubMember[], currentUserId?: number): User[] {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const memberIds = new Set(members.map((m) => m.id));
+
+  return MOCK_STUDENTS.filter((student) => {
+    if (student.id === currentUserId) return false;
+    if (memberIds.has(student.id)) return false;
+    return (
+      student.name.includes(trimmed) ||
+      String(student.studentNumber).includes(trimmed)
+    );
+  }).slice(0, SEARCH_RESULT_LIMIT);
 }
 
 export function ClubDetailSection({ id }: ClubDetailSectionProps) {
@@ -25,8 +47,13 @@ export function ClubDetailSection({ id }: ClubDetailSectionProps) {
   const router = useRouter();
   const autonomousApplyMutation = useApplyAutonomousClub(id);
   const transferMutation = useTransferClubLeader(id);
+  const inviteMutation = useInviteClubMember(id);
+  const exileMutation = useExileClubMember(id);
+
   const [transferTarget, setTransferTarget] = useState<ClubMember | null>(null);
-  const { data: detail, isLoading, isError } = useQuery(clubQueries.detail(id));
+  const [memberSearch, setMemberSearch] = useState("");
+
+  const { data: detail, isLoading, isError, error } = useQuery(clubQueries.detail(id));
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const isLeader = !!user && user.name === detail?.club.leader;
   const canCreateForm = detail?.club.type === "MAJOR_CLUB" && isLeader;
@@ -44,6 +71,12 @@ export function ClubDetailSection({ id }: ClubDetailSectionProps) {
     enabled: canCreateForm,
     retry: false,
   });
+
+  const memberSearchResults = filterSearchResults(
+    memberSearch,
+    detail?.members ?? [],
+    user?.id,
+  );
 
   const handleApplyClick = () => {
     if (!detail || autonomousApplyMutation.isPending) {
@@ -97,6 +130,16 @@ export function ClubDetailSection({ id }: ClubDetailSectionProps) {
     setTransferTarget(null);
   };
 
+  const handleMemberInvite = (invitedUser: User) => {
+    inviteMutation.mutate(invitedUser.id, {
+      onSuccess: () => setMemberSearch(""),
+    });
+  };
+
+  const handleMemberExile = (memberId: number) => {
+    exileMutation.mutate(memberId);
+  };
+
   if (isLoading || isUserLoading) {
     return (
       <div className="flex min-h-0 flex-1 w-full overflow-y-auto xl:px-10 xl:pb-6 2xl:px-18 lg:px-8 sm:px-8">
@@ -114,6 +157,21 @@ export function ClubDetailSection({ id }: ClubDetailSectionProps) {
   }
 
   if (isError || !detail) {
+    const isForbidden =
+      axios.isAxiosError(error) &&
+      error.response?.status === HttpStatusCode.Forbidden;
+
+    if (isForbidden) {
+      return (
+        <div className="flex min-h-0 flex-1 w-full items-center justify-center xl:px-10 xl:pb-6 2xl:px-18 lg:px-8 sm:px-8">
+          <div className="flex flex-col items-center gap-2 text-center">
+            <span className="text-title-3 text-main-text">접근 권한이 없어요</span>
+            <span className="text-text-2 text-sub-1">이 동아리 정보를 볼 수 있는 권한이 없습니다.</span>
+          </div>
+        </div>
+      );
+    }
+
     notFound();
   }
 
@@ -149,6 +207,12 @@ export function ClubDetailSection({ id }: ClubDetailSectionProps) {
                   : undefined
               }
               onTransferClick={isLeader ? handleTransferClick : undefined}
+              onEditClick={isLeader ? () => {} : undefined}
+              memberSearchQuery={memberSearch}
+              memberSearchResults={memberSearchResults}
+              onMemberSearchChange={setMemberSearch}
+              onMemberInvite={isLeader ? handleMemberInvite : undefined}
+              onMemberExile={isLeader ? handleMemberExile : undefined}
             />
           </div>
         </div>

--- a/src/features/club/ui/ClubDetailSection.tsx
+++ b/src/features/club/ui/ClubDetailSection.tsx
@@ -38,7 +38,11 @@ export function ClubDetailSection({ id }: ClubDetailSectionProps) {
 
   const { data: detail, isLoading, isError, error } = useQuery(clubQueries.detail(id));
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
-  const isLeader = !!user && user.name === detail?.club.leader;
+  const isLeader = !!user && (
+    detail?.club.leaderId !== undefined
+      ? user.id === detail.club.leaderId
+      : user.name === detail?.club.leader
+  );
   const canCreateForm = detail?.club.type === "MAJOR_CLUB" && isLeader;
   const canViewApplications =
     !!detail &&

--- a/src/features/club/ui/ClubDetailSection.tsx
+++ b/src/features/club/ui/ClubDetailSection.tsx
@@ -8,9 +8,8 @@ import Club from "@/shared/asset/svg/Club";
 import ClubDetail from "@/entities/club/ui/ClubDetail";
 import { clubQueries } from "@/entities/club/api/clubQueries";
 import { userQueries } from "@/entities/user/api/userQueries";
-import { MOCK_STUDENTS } from "@/entities/user/model/mock";
 import type { ClubMember } from "@/entities/club/model/club";
-import type { User } from "@/entities/user/model/user";
+import type { SearchUser } from "@/entities/user/model/user";
 import { useApplyAutonomousClub } from "../model/useApplyAutonomousClub";
 import { useTransferClubLeader } from "../model/useTransferClubLeader";
 import { useInviteClubMember } from "../model/useInviteClubMember";
@@ -22,23 +21,6 @@ interface ClubDetailSectionProps {
 }
 
 const SEARCH_RESULT_LIMIT = 5;
-
-// TODO: MOCK_STUDENTS를 실제 유저 검색 API(TanStack Query)로 교체해야 합니다.
-function filterSearchResults(query: string, members: ClubMember[], currentUserId?: number): User[] {
-  const trimmed = query.trim();
-  if (!trimmed) return [];
-
-  const memberIds = new Set(members.map((m) => m.id));
-
-  return MOCK_STUDENTS.filter((student) => {
-    if (student.id === currentUserId) return false;
-    if (memberIds.has(student.id)) return false;
-    return (
-      student.name.includes(trimmed) ||
-      String(student.studentNumber).includes(trimmed)
-    );
-  }).slice(0, SEARCH_RESULT_LIMIT);
-}
 
 export function ClubDetailSection({ id }: ClubDetailSectionProps) {
   if (!Number.isInteger(id)) {
@@ -56,11 +38,7 @@ export function ClubDetailSection({ id }: ClubDetailSectionProps) {
 
   const { data: detail, isLoading, isError, error } = useQuery(clubQueries.detail(id));
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
-  const isLeader = !!user && (
-    detail?.club.leaderId !== undefined
-      ? user.id === detail.club.leaderId
-      : user.name === detail?.club.leader
-  );
+  const isLeader = !!user && user.name === detail?.club.leader;
   const canCreateForm = detail?.club.type === "MAJOR_CLUB" && isLeader;
   const canViewApplications =
     !!detail &&
@@ -77,11 +55,15 @@ export function ClubDetailSection({ id }: ClubDetailSectionProps) {
     retry: false,
   });
 
-  const memberSearchResults = filterSearchResults(
-    memberSearch,
-    detail?.members ?? [],
-    user?.id,
-  );
+  const trimmedSearch = memberSearch.trim();
+  const { data: searchUsersPage } = useQuery({
+    ...userQueries.list({ name: trimmedSearch || undefined }),
+    enabled: isLeader && trimmedSearch.length > 0,
+  });
+  const memberIds = new Set((detail?.members ?? []).map((m) => m.id));
+  const memberSearchResults = (searchUsersPage?.content ?? [])
+    .filter((u) => u.id !== user?.id && !memberIds.has(u.id))
+    .slice(0, SEARCH_RESULT_LIMIT);
 
   const handleApplyClick = () => {
     if (!detail || autonomousApplyMutation.isPending) {
@@ -135,7 +117,7 @@ export function ClubDetailSection({ id }: ClubDetailSectionProps) {
     setTransferTarget(null);
   };
 
-  const handleMemberInvite = (invitedUser: User) => {
+  const handleMemberInvite = (invitedUser: SearchUser) => {
     inviteMutation.mutate(invitedUser.id, {
       onSuccess: () => setMemberSearch(""),
     });

--- a/src/features/club/ui/ClubDetailSection.tsx
+++ b/src/features/club/ui/ClubDetailSection.tsx
@@ -56,7 +56,11 @@ export function ClubDetailSection({ id }: ClubDetailSectionProps) {
 
   const { data: detail, isLoading, isError, error } = useQuery(clubQueries.detail(id));
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
-  const isLeader = !!user && user.name === detail?.club.leader;
+  const isLeader = !!user && (
+    detail?.club.leaderId !== undefined
+      ? user.id === detail.club.leaderId
+      : user.name === detail?.club.leader
+  );
   const canCreateForm = detail?.club.type === "MAJOR_CLUB" && isLeader;
   const canViewApplications =
     !!detail &&

--- a/src/features/club/ui/ClubDetailSection.tsx
+++ b/src/features/club/ui/ClubDetailSection.tsx
@@ -23,6 +23,7 @@ interface ClubDetailSectionProps {
 
 const SEARCH_RESULT_LIMIT = 5;
 
+// TODO: MOCK_STUDENTS를 실제 유저 검색 API(TanStack Query)로 교체해야 합니다.
 function filterSearchResults(query: string, members: ClubMember[], currentUserId?: number): User[] {
   const trimmed = query.trim();
   if (!trimmed) return [];


### PR DESCRIPTION
## #️⃣연관된 이슈

#52 #60

## 📝작업 내용

### 동아리 멤버 초대
- `clubMutations.inviteMember` 추가 (POST /clubs/{clubId}/member/{userId})
- `useInviteClubMember` 훅 구현 — 초대 성공 시 쿼리 무효화 및 토스트 알림
- MSW mock 핸들러 추가 (중복 멤버 409 처리 포함)

### 동아리 멤버 추방
- `clubMutations.exileMember` 추가 (DELETE /clubs/{clubId}/member/exile/{userId})
- `useExileClubMember` 훅 구현 — 추방 성공 시 쿼리 무효화 및 토스트 알림
- MSW mock 핸들러 추가

### 동아리 상세 UI
- 부장 전용 수정하기(Edit) 버튼 추가 — 클릭 시 부원 추가 섹션 토글
- 부원 추가 섹션: 이름·학번 검색 드롭다운 → 선택 즉시 초대 API 호출
- 현재 멤버 칩(pill) 표시 — X 클릭 시 추방 API 호출
- 403 Forbidden 에러 별도 처리 (권한 없음 안내 UI)

## 💬리뷰 요구사항(선택)

- filterSearchResults 에서 현재 MOCK_STUDENTS를 사용하고 있어, 실제 유저 검색 API 연동 시 교체가 필요합니다.