### PR TITLE
fix: 에러 폴백 렌더링 방식 수정

### DIFF
--- a/src/shared/ui/QueryErrorBoundary.tsx
+++ b/src/shared/ui/QueryErrorBoundary.tsx
@@ -58,7 +58,7 @@ class InnerErrorBoundary extends Component<
     const { error } = this.state;
 
     if (error) {
-      const Fallback = this.props.fallback;
+      const { fallback: Fallback } = this.props;
 
       return (
         <Fallback error={error} resetErrorBoundary={this.resetErrorBoundary} />

--- a/src/shared/ui/QueryErrorBoundary.tsx
+++ b/src/shared/ui/QueryErrorBoundary.tsx
@@ -3,6 +3,7 @@
 import {
   Component,
   Suspense,
+  type ComponentType,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
@@ -15,13 +16,13 @@ export interface QueryErrorFallbackProps {
 
 interface QueryErrorBoundaryProps {
   children: ReactNode;
-  fallback: (props: QueryErrorFallbackProps) => ReactNode;
+  fallback: ComponentType<QueryErrorFallbackProps>;
 }
 
 interface ClientQueryBoundaryProps {
   children: ReactNode;
   loadingFallback: ReactNode;
-  errorFallback: (props: QueryErrorFallbackProps) => ReactNode;
+  errorFallback: ComponentType<QueryErrorFallbackProps>;
 }
 
 interface InnerErrorBoundaryProps extends QueryErrorBoundaryProps {
@@ -57,10 +58,14 @@ class InnerErrorBoundary extends Component<
     const { error } = this.state;
 
     if (error) {
-      return this.props.fallback({
-        error,
-        resetErrorBoundary: this.resetErrorBoundary,
-      });
+      const Fallback = this.props.fallback;
+
+      return (
+        <Fallback
+          error={error}
+          resetErrorBoundary={this.resetErrorBoundary}
+        />
+      );
     }
 
     return this.props.children;

--- a/src/shared/ui/QueryErrorBoundary.tsx
+++ b/src/shared/ui/QueryErrorBoundary.tsx
@@ -61,10 +61,7 @@ class InnerErrorBoundary extends Component<
       const Fallback = this.props.fallback;
 
       return (
-        <Fallback
-          error={error}
-          resetErrorBoundary={this.resetErrorBoundary}
-        />
+        <Fallback error={error} resetErrorBoundary={this.resetErrorBoundary} />
       );
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

shared UI의 `QueryErrorBoundary`에서 에러 fallback을 일반 함수처럼 직접 호출하던 방식을 React 컴포넌트 렌더링 방식으로 수정했습니다.

- fallback 타입을 `ComponentType<QueryErrorFallbackProps>`로 명확히 변경
- 에러 발생 시 `<Fallback />` 형태로 렌더링하도록 변경
- 쿼리 실패 상황에서 fallback 내부 hook 또는 React Compiler 내부 hook이 React 렌더링 컨텍스트 밖에서 실행되는 문제 방지