### PR TITLE
fix: UI 문구 표기 오류 수정

### DIFF
--- a/src/features/club/ui/ClubSearch.tsx
+++ b/src/features/club/ui/ClubSearch.tsx
@@ -21,7 +21,7 @@ export default function ClubSearch({
     <div className="flex w-full min-w-82.5 flex-col items-start gap-4">
       <div className="w-full">
         <TextField
-          placeholder="동아리명, 부장 이름등을 입력해주세요"
+          placeholder="동아리명, 부장 이름 등을 입력해주세요"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
+++ b/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
@@ -116,7 +116,7 @@ export function WakeUpMusicSection({
           {isHovered && (
             <div className="pointer-events-none absolute right-0 bottom-full mb-4">
               <div className="bg-surface text-sub-1 relative rounded-lg px-4 py-2 text-sm font-medium whitespace-nowrap shadow-[0_0_24px_rgba(0,0,0,0.1)]">
-                오늘의 노래를 <span className="text-p-1">ai</span>한테 추천
+                오늘의 노래를 <span className="text-p-1">AI</span>한테 추천
                 받아봐요!
                 <div className="bg-background-surface absolute right-[22px] -bottom-1.5 h-3 w-3 rotate-45"></div>
               </div>

--- a/src/widgets/main/ui/HomebaseCard.tsx
+++ b/src/widgets/main/ui/HomebaseCard.tsx
@@ -138,7 +138,7 @@ export default function HomebaseCard({
           <div className="flex w-full min-w-0 flex-col gap-4 lg:w-full">
             <div className="relative">
               <TextField
-                placeholder="이름, 학번등을 입력해주세요"
+                placeholder="이름, 학번 등을 입력해주세요"
                 value={name}
                 onChange={(event) => handleNameChange(event.target.value)}
                 onKeyDown={handleNameKeyDown}


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- `features/club`의 동아리 검색 placeholder에서 `등` 앞 띄어쓰기를 수정했습니다.
- `widgets/main`의 홈베이스 카드 검색 placeholder에서 `등` 앞 띄어쓰기를 수정했습니다.
- `features/wake-up-music`의 추천 말풍선 문구에서 `ai` 표기를 `AI`로 수정했습니다.

### 스크린샷 (선택)

UI 문구만 수정되어 별도 스크린샷은 첨부하지 않았습니다.