### PR TITLE
feat: 기숙사 신청 취소 UI 연동

### DIFF
--- a/src/features/massage-chair/model/useCancelMassage.ts
+++ b/src/features/massage-chair/model/useCancelMassage.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
+import {
+  dormitoryMutations,
+  dormitoryQueries,
+} from "@/entities/dormitory/api/dormitoryQueries";
+
+export function useCancelMassage() {
+  const queryClient = useQueryClient();
+  const massageQuery = dormitoryQueries.massage();
+
+  return useMutation({
+    mutationFn: dormitoryMutations.cancelMassage,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: massageQuery.queryKey }),
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.NotFound) {
+        toast.error("안마의자 신청 내역이 없습니다.");
+        return;
+      }
+
+      toast.error("안마의자 취소에 실패했습니다.");
+    },
+  });
+}

--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -5,12 +5,38 @@ import Chair from "@/shared/asset/svg/Chair";
 import { ProfileCard } from "@/entities/user/ui/ProfileCard";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
+import { userQueries } from "@/entities/user/api/userQueries";
 import { useApplyMassage } from "../model/useApplyMassage";
+import { useCancelMassage } from "../model/useCancelMassage";
 
 export function MassageChairSection() {
   const massageQuery = dormitoryQueries.massage();
   const { data: applicants = [] } = useQuery(massageQuery);
+  const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const applyMutation = useApplyMassage();
+  const cancelMutation = useCancelMassage();
+  const hasAppliedMassage =
+    user !== undefined &&
+    applicants.some((student) => student.studentNumber === user.studentNumber);
+  const isMassageActionPending =
+    applyMutation.isPending || cancelMutation.isPending;
+  const isMassageActionDisabled = isUserLoading || isMassageActionPending;
+
+  const handleApplyMassage = () => {
+    if (isMassageActionDisabled || hasAppliedMassage) {
+      return;
+    }
+
+    applyMutation.mutate();
+  };
+
+  const handleCancelMassage = () => {
+    if (isMassageActionDisabled || !hasAppliedMassage) {
+      return;
+    }
+
+    cancelMutation.mutate();
+  };
 
   return (
     <section className="bg-background-surface flex flex-col gap-6 rounded-2xl p-6">
@@ -40,11 +66,18 @@ export function MassageChairSection() {
 
         <div className="flex w-[330px] shrink-0 flex-col justify-end gap-3">
           <TextButton
-            variant="filled"
+            variant={isMassageActionDisabled ? "disabled" : "filled"}
             size="wide"
-            onClick={() => applyMutation.mutate()}
+            disabled={isMassageActionDisabled}
+            onClick={
+              hasAppliedMassage ? handleCancelMassage : handleApplyMassage
+            }
           >
-            신청하기
+            {isUserLoading
+              ? "확인 중"
+              : hasAppliedMassage
+                ? "취소하기"
+                : "신청하기"}
           </TextButton>
           <p className="text-sub-2 text-caption-2">
             안마의자 신청시간은 20:20 ~ 21:00 입니다

--- a/src/features/self-study/model/useCancelStudy.ts
+++ b/src/features/self-study/model/useCancelStudy.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
+import {
+  dormitoryMutations,
+  dormitoryQueries,
+} from "@/entities/dormitory/api/dormitoryQueries";
+
+export function useCancelStudy() {
+  const queryClient = useQueryClient();
+  const studyQuery = dormitoryQueries.study();
+
+  return useMutation({
+    mutationFn: dormitoryMutations.cancelStudy,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey }),
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.NotFound) {
+        toast.error("자습 신청 내역이 없습니다.");
+        return;
+      }
+
+      toast.error("자습 취소에 실패했습니다.");
+    },
+  });
+}

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -11,6 +11,7 @@ import { userQueries } from "@/entities/user/api/userQueries";
 import { isManagementRole } from "@/entities/user/lib/userRole";
 import { useStudyFilter } from "../model/useStudyFilter";
 import { useApplyStudy } from "../model/useApplyStudy";
+import { useCancelStudy } from "../model/useCancelStudy";
 import { useCheckStudyAttendance } from "../model/useCheckStudyAttendance";
 import { useStudyAttendanceSubscription } from "../model/useStudyAttendanceSubscription";
 import { StudyApplicantCard } from "./StudyApplicantCard";
@@ -26,9 +27,15 @@ export function SelfStudySection() {
   const { searchQuery, selectedGrades, selectedClasses, selectedGender } =
     state;
   const applyMutation = useApplyStudy();
+  const cancelMutation = useCancelStudy();
   const isStudyBanned = user?.isBanned === true;
-  const isApplyDisabled =
-    isUserLoading || isStudyBanned || applyMutation.isPending;
+  const hasAppliedStudy =
+    user !== undefined &&
+    students.some((student) => student.userId === user.id);
+  const isStudyActionPending =
+    applyMutation.isPending || cancelMutation.isPending;
+  const isStudyActionDisabled =
+    isUserLoading || isStudyBanned || isStudyActionPending;
   const canManageStudy = isManagementRole(user?.role);
   const { checkedStudentIds, markChecked } = useStudyAttendanceSubscription(
     user?.role,
@@ -50,11 +57,19 @@ export function SelfStudySection() {
       payload: selectedGender === gender ? null : gender,
     });
   const handleApplyStudy = () => {
-    if (isApplyDisabled) {
+    if (isStudyActionDisabled || hasAppliedStudy) {
       return;
     }
 
     applyMutation.mutate();
+  };
+
+  const handleCancelStudy = () => {
+    if (isStudyActionDisabled || !hasAppliedStudy) {
+      return;
+    }
+
+    cancelMutation.mutate();
   };
 
   const handleCheckAttendance = (studentId: number) => {
@@ -184,19 +199,21 @@ export function SelfStudySection() {
             variant={
               isStudyBanned
                 ? "negative"
-                : isApplyDisabled
+                : isStudyActionDisabled
                   ? "disabled"
                   : "filled"
             }
             size="wide"
-            disabled={isApplyDisabled}
-            onClick={handleApplyStudy}
+            disabled={isStudyActionDisabled}
+            onClick={hasAppliedStudy ? handleCancelStudy : handleApplyStudy}
           >
             {isStudyBanned
               ? "자습 금지를 당했어요!"
               : isUserLoading
                 ? "확인 중"
-                : "신청하기"}
+                : hasAppliedStudy
+                  ? "취소하기"
+                  : "신청하기"}
           </TextButton>
 
           <p className="text-sub-2 text-caption-2">

--- a/src/widgets/main/ui/MassageApplyCard.tsx
+++ b/src/widgets/main/ui/MassageApplyCard.tsx
@@ -3,7 +3,9 @@
 import { useQuery } from "@tanstack/react-query";
 import ChairIcon from "@/shared/asset/svg/Chair";
 import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
+import { userQueries } from "@/entities/user/api/userQueries";
 import { useApplyMassage } from "@/features/massage-chair/model/useApplyMassage";
+import { useCancelMassage } from "@/features/massage-chair/model/useCancelMassage";
 import ApplyCard from "./ApplyCard";
 
 const MASSAGE_MAX = 5;
@@ -11,7 +13,31 @@ const MASSAGE_MAX = 5;
 export default function MassageApplyCard() {
   const massageQuery = dormitoryQueries.massage();
   const { data: applicants = [] } = useQuery(massageQuery);
+  const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const applyMutation = useApplyMassage();
+  const cancelMutation = useCancelMassage();
+  const hasAppliedMassage =
+    user !== undefined &&
+    applicants.some((student) => student.studentNumber === user.studentNumber);
+  const isMassageActionPending =
+    applyMutation.isPending || cancelMutation.isPending;
+  const isMassageActionDisabled = isUserLoading || isMassageActionPending;
+
+  const handleApplyMassage = () => {
+    if (isMassageActionDisabled || hasAppliedMassage) {
+      return;
+    }
+
+    applyMutation.mutate();
+  };
+
+  const handleCancelMassage = () => {
+    if (isMassageActionDisabled || !hasAppliedMassage) {
+      return;
+    }
+
+    cancelMutation.mutate();
+  };
 
   return (
     <ApplyCard
@@ -20,10 +46,13 @@ export default function MassageApplyCard() {
       current={applicants.length}
       total={MASSAGE_MAX}
       timeText="안마 의자 신청 시간은 20:20 ~ 21:00에 신청이 가능해요"
-      buttonText="신청"
+      buttonText={
+        isUserLoading ? "확인 중" : hasAppliedMassage ? "취소" : "신청"
+      }
       detailHref="/dormitory"
       femaleNotice
-      onApply={() => applyMutation.mutate()}
+      disabled={isMassageActionDisabled}
+      onApply={hasAppliedMassage ? handleCancelMassage : handleApplyMassage}
     />
   );
 }

--- a/src/widgets/main/ui/StudyApplyCard.tsx
+++ b/src/widgets/main/ui/StudyApplyCard.tsx
@@ -5,6 +5,7 @@ import BookIcon from "@/shared/asset/svg/ApplyStudy";
 import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
 import { userQueries } from "@/entities/user/api/userQueries";
 import { useApplyStudy } from "@/features/self-study/model/useApplyStudy";
+import { useCancelStudy } from "@/features/self-study/model/useCancelStudy";
 import ApplyCard from "./ApplyCard";
 
 const STUDY_MAX = 50;
@@ -14,16 +15,30 @@ export default function StudyApplyCard() {
   const { data: students = [] } = useQuery(studyQuery);
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const applyMutation = useApplyStudy();
+  const cancelMutation = useCancelStudy();
   const isStudyBanned = user?.isBanned === true;
-  const isApplyDisabled =
-    isUserLoading || isStudyBanned || applyMutation.isPending;
+  const hasAppliedStudy =
+    user !== undefined &&
+    students.some((student) => student.userId === user.id);
+  const isStudyActionPending =
+    applyMutation.isPending || cancelMutation.isPending;
+  const isStudyActionDisabled =
+    isUserLoading || isStudyBanned || isStudyActionPending;
 
   const handleApplyStudy = () => {
-    if (isApplyDisabled) {
+    if (isStudyActionDisabled || hasAppliedStudy) {
       return;
     }
 
     applyMutation.mutate();
+  };
+
+  const handleCancelStudy = () => {
+    if (isStudyActionDisabled || !hasAppliedStudy) {
+      return;
+    }
+
+    cancelMutation.mutate();
   };
 
   return (
@@ -38,13 +53,15 @@ export default function StudyApplyCard() {
           ? "자습 금지를 당했어요!"
           : isUserLoading
             ? "확인 중"
-            : "신청"
+            : hasAppliedStudy
+              ? "취소"
+              : "신청"
       }
       buttonVariant={isStudyBanned ? "negative" : "filled"}
       buttonSize={isStudyBanned ? "fit" : "small"}
       detailHref="/dormitory"
-      disabled={isApplyDisabled}
-      onApply={handleApplyStudy}
+      disabled={isStudyActionDisabled}
+      onApply={hasAppliedStudy ? handleCancelStudy : handleApplyStudy}
     />
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 자습 취소 mutation 훅을 추가하고 자습 신청 목록에서 현재 사용자의 신청 여부를 판단해 신청/취소 버튼을 전환했습니다.
- 안마의자 취소 mutation 훅을 추가하고 안마의자 신청 목록에서 현재 사용자의 신청 여부를 판단해 신청/취소 버튼을 전환했습니다.
- 신청/취소 요청 중에는 버튼을 비활성화하고, 취소 대상이 없는 경우 404 응답에 맞는 토스트 메시지를 표시하도록 처리했습니다.
- 자습 금지 상태에서는 기존 금지 UI를 유지하고 신청/취소 동작이 실행되지 않도록 했습니다.

### 스크린샷 (선택)

UI 상태 전환 로직 변경이며 별도 스크린샷은 첨부하지 않았습니다.