### PR TITLE
fix: 토큰 리프레시 실패 시 무한루프 수정

### DIFF
--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -45,7 +45,9 @@ export async function POST(request: NextRequest) {
       }
 
       if (status === HttpStatusCode.Unauthorized) {
-        return NextResponse.json(body, { status });
+        const res = NextResponse.json(body, { status });
+        res.cookies.delete("refresh_token");
+        return res;
       }
 
       if (status === HttpStatusCode.InternalServerError) {

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -1,4 +1,8 @@
-import axios, { HttpStatusCode } from "axios";
+import axios, { HttpStatusCode, type InternalAxiosRequestConfig } from "axios";
+
+interface RetryableRequestConfig extends InternalAxiosRequestConfig {
+  _retried?: boolean;
+}
 
 export const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -16,6 +20,7 @@ const authPathsWithoutRefresh = [
 ];
 
 let refreshPromise: Promise<string> | null = null;
+let isSessionExpired = false;
 
 instance.interceptors.request.use((config) => {
   if (config.url?.startsWith("/api/")) {
@@ -36,11 +41,12 @@ instance.interceptors.response.use(
   async (error) => {
     if (typeof window === "undefined") return Promise.reject(error);
 
-    const originalRequest = error.config;
+    const originalRequest = error.config as RetryableRequestConfig;
 
     if (
       error.response?.status === HttpStatusCode.Unauthorized &&
       !originalRequest._retried &&
+      !isSessionExpired &&
       !authPathsWithoutRefresh.some((path) =>
         originalRequest.url?.includes(path),
       )
@@ -67,9 +73,11 @@ instance.interceptors.response.use(
         const accessToken = await refreshPromise;
         originalRequest.headers.Authorization = `Bearer ${accessToken}`;
         return instance(originalRequest);
-      } catch {
+      } catch (refreshError) {
+        isSessionExpired = true;
         sessionStorage.removeItem("access_token");
         window.location.href = "/signin";
+        return Promise.reject(refreshError);
       }
     }
 

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -15,7 +15,6 @@ const authPathsWithoutRefresh = [
   "/api/auth/signout",
 ];
 
-const retriedRequests = new WeakSet<object>();
 let refreshPromise: Promise<string> | null = null;
 
 instance.interceptors.request.use((config) => {
@@ -41,10 +40,10 @@ instance.interceptors.response.use(
 
     if (
       error.response?.status === HttpStatusCode.Unauthorized &&
-      !retriedRequests.has(config) &&
+      !config.headers["x-retried"] &&
       !authPathsWithoutRefresh.some((path) => config.url?.includes(path))
     ) {
-      retriedRequests.add(config);
+      config.headers["x-retried"] = "true";
 
       try {
         if (!refreshPromise) {

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -48,17 +48,15 @@ instance.interceptors.response.use(
 
       try {
         if (!refreshPromise) {
-          refreshPromise = axios
-            .post("/api/auth/refresh")
-            .then(({ data }) => {
-              const token = data.data?.accessToken;
-              if (!token) {
-                throw new Error("Access token is missing");
-              }
-              sessionStorage.setItem("access_token", token);
-              refreshPromise = null;
-              return token;
-            });
+          refreshPromise = axios.post("/api/auth/refresh").then(({ data }) => {
+            const token = data.data?.accessToken;
+            if (!token) {
+              throw new Error("Access token is missing");
+            }
+            sessionStorage.setItem("access_token", token);
+            refreshPromise = null;
+            return token;
+          });
         }
 
         const accessToken = await refreshPromise;

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -1,8 +1,4 @@
-import axios, { HttpStatusCode, type InternalAxiosRequestConfig } from "axios";
-
-interface RetryableRequestConfig extends InternalAxiosRequestConfig {
-  _retried?: boolean;
-}
+import axios, { HttpStatusCode } from "axios";
 
 export const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -19,8 +15,8 @@ const authPathsWithoutRefresh = [
   "/api/auth/signout",
 ];
 
+const retriedRequests = new WeakSet<object>();
 let refreshPromise: Promise<string> | null = null;
-let isSessionExpired = false;
 
 instance.interceptors.request.use((config) => {
   if (config.url?.startsWith("/api/")) {
@@ -41,17 +37,14 @@ instance.interceptors.response.use(
   async (error) => {
     if (typeof window === "undefined") return Promise.reject(error);
 
-    const originalRequest = error.config as RetryableRequestConfig;
+    const config = error.config;
 
     if (
       error.response?.status === HttpStatusCode.Unauthorized &&
-      !originalRequest._retried &&
-      !isSessionExpired &&
-      !authPathsWithoutRefresh.some((path) =>
-        originalRequest.url?.includes(path),
-      )
+      !retriedRequests.has(config) &&
+      !authPathsWithoutRefresh.some((path) => config.url?.includes(path))
     ) {
-      originalRequest._retried = true;
+      retriedRequests.add(config);
 
       try {
         if (!refreshPromise) {
@@ -63,18 +56,15 @@ instance.interceptors.response.use(
                 throw new Error("Access token is missing");
               }
               sessionStorage.setItem("access_token", token);
-              return token;
-            })
-            .finally(() => {
               refreshPromise = null;
+              return token;
             });
         }
 
         const accessToken = await refreshPromise;
-        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-        return instance(originalRequest);
+        config.headers.Authorization = `Bearer ${accessToken}`;
+        return instance(config);
       } catch (refreshError) {
-        isSessionExpired = true;
         sessionStorage.removeItem("access_token");
         window.location.href = "/signin";
         return Promise.reject(refreshError);


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

`POST /api/auth/refresh 401` → `GET / 200` 패턴이 무한 반복되는 버그를 수정합니다.

세 레이어가 서로 다른 환경에서 실행되며 인증 상태가 불일치해 루프가 발생했습니다.

- **`proxy.ts` (미들웨어, 서버)**: `refresh_token` 쿠키 존재 여부만 확인 → `/signin` 접근 시 쿠키 있으면 `/`로 리다이렉트
- **`instance.ts` (Axios, 클라이언트)**: `access_token` 만료 시 리프레시 시도, 실패 시 `/signin` 이동 — 단, httpOnly 쿠키 삭제 불가
- **`refresh/route.ts` (Route Handler, 서버)**: 리프레시 실패 시 `refresh_token` 쿠키를 삭제하지 않아 미들웨어가 계속 `/`로 리다이렉트

### `app/api/auth/refresh/route.ts`

백엔드가 401을 반환할 때 `refresh_token` 쿠키를 응답에서 삭제하도록 수정. 이후 미들웨어가 쿠키 없음을 감지해 `/signin`에서 `/`로 리다이렉트하지 않음.

### `src/shared/api/instance.ts` (shared 레이어)

- 재시도 추적 방식을 `x-retried` 헤더 마커로 변경: Axios는 `instance(config)` 재시도 시 `mergeConfig`로 새 객체를 생성하므로 WeakSet 참조 추적이 실패함. 헤더는 merge 시 유지되므로 재시도 여부를 안정적으로 추적 가능.
- `.finally(() => refreshPromise = null)` 제거 → 리프레시 실패 시 `refreshPromise`가 rejected 상태로 유지되어 이후 새 401 요청이 즉시 catch로 떨어짐

## 💬리뷰 요구사항(선택)

`x-retried` 헤더는 Axios merge 시 유지되므로 재시도 요청에서도 정상 감지됩니다. 서버로 해당 헤더가 전송되나 백엔드에서 별도 처리 없이 무시됩니다.