### PR TITLE
fix: 오류 상태 UI 표시 개선

### DIFF
--- a/app/callback/page.tsx
+++ b/app/callback/page.tsx
@@ -57,7 +57,7 @@ function CallbackInner() {
           </div>
           <TextButton
             variant="filled"
-            size="wide"
+            size="fit"
             onClick={() => router.replace("/signin")}
           >
             다시 로그인

--- a/src/features/club/ui/ClubOpeningRequestSection.tsx
+++ b/src/features/club/ui/ClubOpeningRequestSection.tsx
@@ -7,8 +7,10 @@ import ClubCard from "@/entities/club/ui/ClubCard";
 
 export function ClubOpeningRequestSection() {
   const router = useRouter();
-  const { data } = useQuery(clubQueries.openingRequests());
+  const { data, isError } = useQuery(clubQueries.openingRequests());
   const clubs = data?.clubs ?? [];
+
+  if (isError) return null;
 
   if (clubs.length === 0) return null;
 

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -73,12 +73,12 @@ function TimeTableCardLoading() {
 
 function TimeTableCardError({ resetErrorBoundary }: QueryErrorFallbackProps) {
   return (
-    <div className="bg-background-surface flex h-[140px] w-full flex-col rounded-2xl p-6 2xl:h-[354px]">
-      <div className="mb-4 flex items-center gap-1">
+    <div className="bg-background-surface flex h-[140px] w-full flex-col overflow-hidden rounded-2xl p-6 2xl:h-[354px]">
+      <div className="mb-2 flex items-center gap-1">
         <Calendar />
         <span className="text-text-1 text-main-text font-semibold">시간표</span>
       </div>
-      <div className="flex flex-1 flex-col items-center justify-center gap-3">
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3">
         <span className="text-text-3 text-negative font-medium">
           시간표를 불러오지 못했습니다.
         </span>


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 동아리 개설 요청 목록 조회 실패 시 섹션을 렌더링하지 않도록 처리했습니다.
- 메인 시간표 카드의 오류 상태 레이아웃이 카드 영역을 벗어나지 않도록 조정했습니다.
- 콜백 페이지의 다시 로그인 버튼이 카드 영역을 벗어나지 않도록 조정했습니다.

### 스크린샷 (선택)

동아리 개설 요청 목록 조회 실패 시 모든 동아리 요청이 보이지 않던 문제입니다.

<img width="1151" height="646" alt="2026-05-10_11-47-14" src="https://github.com/user-attachments/assets/9175cd47-53b1-472a-b0d7-5bb8b7961df1" />
