### PR TITLE
chore: 릴리즈 PR 검증 및 버전 갱신

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,46 @@ on:
 
 jobs:
   # ─────────────────────────────────────────────
+  # 0. develop → main 릴리즈 PR 버전 검사
+  # ─────────────────────────────────────────────
+  release-version-check:
+    name: Release Version Check
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: PR 제목 및 package 버전 검사
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ ! "$PR_TITLE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "develop → main PR 제목은 vX.Y.Z 형식이어야 합니다. 예: v0.2.2"
+            echo "현재 PR 제목: $PR_TITLE"
+            exit 1
+          fi
+
+          RELEASE_VERSION="${PR_TITLE#v}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          LOCKFILE_VERSION="$(node -p "require('./package-lock.json').version")"
+          LOCKFILE_ROOT_VERSION="$(node -p "require('./package-lock.json').packages[''].version")"
+
+          if [[ "$PACKAGE_VERSION" != "$RELEASE_VERSION" ]]; then
+            echo "package.json version이 PR 제목 버전과 일치해야 합니다."
+            echo "PR 제목 버전: $RELEASE_VERSION"
+            echo "package.json version: $PACKAGE_VERSION"
+            exit 1
+          fi
+
+          if [[ "$LOCKFILE_VERSION" != "$RELEASE_VERSION" || "$LOCKFILE_ROOT_VERSION" != "$RELEASE_VERSION" ]]; then
+            echo "package-lock.json version이 PR 제목 버전과 일치해야 합니다."
+            echo "PR 제목 버전: $RELEASE_VERSION"
+            echo "package-lock.json version: $LOCKFILE_VERSION"
+            echo "package-lock.json packages[''].version: $LOCKFILE_ROOT_VERSION"
+            exit 1
+          fi
+
+  # ─────────────────────────────────────────────
   # 1. ESLint 린트 검사
   # ─────────────────────────────────────────────
   lint:
@@ -59,7 +99,13 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, type-check, format-check]
+    needs: [release-version-check, lint, type-check, format-check]
+    if: |
+      always() &&
+      needs.lint.result == 'success' &&
+      needs.type-check.result == 'success' &&
+      needs.format-check.result == 'success' &&
+      (needs.release-version-check.result == 'success' || needs.release-version-check.result == 'skipped')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -75,7 +121,7 @@ jobs:
   discord-ci-failure:
     name: Discord CI 실패 알림
     runs-on: ubuntu-latest
-    needs: [lint, type-check, format-check, build]
+    needs: [release-version-check, lint, type-check, format-check, build]
     if: failure()
     steps:
       - name: Discord 알림 전송

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -56,7 +56,7 @@ jobs:
 
           # ── 상태 & 콘텐츠 ──────────────────────
           status: ${{ job.status }}
-          content: "<@1445205237462863922> PR 확인해주세요."
+          content: "<@&1445205237462863922> PR 확인해주세요."
           title: "${{ github.event.pull_request.title }}"
           description: |
             작성자: @${{ github.event.pull_request.user.login }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flooding-v2",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flooding-v2",
-      "version": "0.1.0",
+      "version": "0.2.2",
       "dependencies": {
         "@sun-typeface/suit": "^2.0.5",
         "@tanstack/react-query": "^5.90.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flooding-v2",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- `develop` → `main` 릴리즈 PR에서 제목이 `vX.Y.Z` 형식인지 검사하는 CI job을 추가했습니다.
- PR 제목 버전과 `package.json`, `package-lock.json` 버전이 일치해야 CI가 통과하도록 검증을 추가했습니다.
- 릴리즈 검증 job이 스킵되는 일반 PR에서는 기존 lint/type/format/build 흐름이 유지되도록 build 조건을 조정했습니다.
- Discord PR 오픈 알림의 멘션을 역할 멘션 형식(`<@&...>`)으로 수정했습니다.
- 패키지 버전을 `0.2.2`로 갱신했습니다.