### PR TITLE
v2026.0510.1225

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,46 @@ on:
 
 jobs:
   # ─────────────────────────────────────────────
+  # 0. develop → main 릴리즈 PR 버전 검사
+  # ─────────────────────────────────────────────
+  release-version-check:
+    name: Release Version Check
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: PR 제목 및 package 버전 검사
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ ! "$PR_TITLE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "develop → main PR 제목은 vX.Y.Z 형식이어야 합니다. 예: v0.2.2"
+            echo "현재 PR 제목: $PR_TITLE"
+            exit 1
+          fi
+
+          RELEASE_VERSION="${PR_TITLE#v}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          LOCKFILE_VERSION="$(node -p "require('./package-lock.json').version")"
+          LOCKFILE_ROOT_VERSION="$(node -p "require('./package-lock.json').packages[''].version")"
+
+          if [[ "$PACKAGE_VERSION" != "$RELEASE_VERSION" ]]; then
+            echo "package.json version이 PR 제목 버전과 일치해야 합니다."
+            echo "PR 제목 버전: $RELEASE_VERSION"
+            echo "package.json version: $PACKAGE_VERSION"
+            exit 1
+          fi
+
+          if [[ "$LOCKFILE_VERSION" != "$RELEASE_VERSION" || "$LOCKFILE_ROOT_VERSION" != "$RELEASE_VERSION" ]]; then
+            echo "package-lock.json version이 PR 제목 버전과 일치해야 합니다."
+            echo "PR 제목 버전: $RELEASE_VERSION"
+            echo "package-lock.json version: $LOCKFILE_VERSION"
+            echo "package-lock.json packages[''].version: $LOCKFILE_ROOT_VERSION"
+            exit 1
+          fi
+
+  # ─────────────────────────────────────────────
   # 1. ESLint 린트 검사
   # ─────────────────────────────────────────────
   lint:
@@ -59,7 +99,13 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, type-check, format-check]
+    needs: [release-version-check, lint, type-check, format-check]
+    if: |
+      always() &&
+      needs.lint.result == 'success' &&
+      needs.type-check.result == 'success' &&
+      needs.format-check.result == 'success' &&
+      (needs.release-version-check.result == 'success' || needs.release-version-check.result == 'skipped')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -75,7 +121,7 @@ jobs:
   discord-ci-failure:
     name: Discord CI 실패 알림
     runs-on: ubuntu-latest
-    needs: [lint, type-check, format-check, build]
+    needs: [release-version-check, lint, type-check, format-check, build]
     if: failure()
     steps:
       - name: Discord 알림 전송

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -56,7 +56,7 @@ jobs:
 
           # ── 상태 & 콘텐츠 ──────────────────────
           status: ${{ job.status }}
-          content: "<@1445205237462863922> PR 확인해주세요."
+          content: "<@&1445205237462863922> PR 확인해주세요."
           title: "${{ github.event.pull_request.title }}"
           description: |
             작성자: @${{ github.event.pull_request.user.login }}

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -45,7 +45,9 @@ export async function POST(request: NextRequest) {
       }
 
       if (status === HttpStatusCode.Unauthorized) {
-        return NextResponse.json(body, { status });
+        const res = NextResponse.json(body, { status });
+        res.cookies.delete("refresh_token");
+        return res;
       }
 
       if (status === HttpStatusCode.InternalServerError) {

--- a/app/callback/page.tsx
+++ b/app/callback/page.tsx
@@ -57,7 +57,7 @@ function CallbackInner() {
           </div>
           <TextButton
             variant="filled"
-            size="wide"
+            size="fit"
             onClick={() => router.replace("/signin")}
           >
             다시 로그인

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flooding-v2",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flooding-v2",
-      "version": "0.1.0",
+      "version": "0.2.2",
       "dependencies": {
         "@sun-typeface/suit": "^2.0.5",
         "@tanstack/react-query": "^5.90.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flooding-v2",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/features/club/ui/ClubOpeningRequestSection.tsx
+++ b/src/features/club/ui/ClubOpeningRequestSection.tsx
@@ -7,8 +7,10 @@ import ClubCard from "@/entities/club/ui/ClubCard";
 
 export function ClubOpeningRequestSection() {
   const router = useRouter();
-  const { data } = useQuery(clubQueries.openingRequests());
+  const { data, isError } = useQuery(clubQueries.openingRequests());
   const clubs = data?.clubs ?? [];
+
+  if (isError) return null;
 
   if (clubs.length === 0) return null;
 

--- a/src/features/massage-chair/model/useCancelMassage.ts
+++ b/src/features/massage-chair/model/useCancelMassage.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
+import {
+  dormitoryMutations,
+  dormitoryQueries,
+} from "@/entities/dormitory/api/dormitoryQueries";
+
+export function useCancelMassage() {
+  const queryClient = useQueryClient();
+  const massageQuery = dormitoryQueries.massage();
+
+  return useMutation({
+    mutationFn: dormitoryMutations.cancelMassage,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: massageQuery.queryKey }),
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.NotFound) {
+        toast.error("안마의자 신청 내역이 없습니다.");
+        return;
+      }
+
+      toast.error("안마의자 취소에 실패했습니다.");
+    },
+  });
+}

--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -5,12 +5,38 @@ import Chair from "@/shared/asset/svg/Chair";
 import { ProfileCard } from "@/entities/user/ui/ProfileCard";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
+import { userQueries } from "@/entities/user/api/userQueries";
 import { useApplyMassage } from "../model/useApplyMassage";
+import { useCancelMassage } from "../model/useCancelMassage";
 
 export function MassageChairSection() {
   const massageQuery = dormitoryQueries.massage();
   const { data: applicants = [] } = useQuery(massageQuery);
+  const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const applyMutation = useApplyMassage();
+  const cancelMutation = useCancelMassage();
+  const hasAppliedMassage =
+    user !== undefined &&
+    applicants.some((student) => student.studentNumber === user.studentNumber);
+  const isMassageActionPending =
+    applyMutation.isPending || cancelMutation.isPending;
+  const isMassageActionDisabled = isUserLoading || isMassageActionPending;
+
+  const handleApplyMassage = () => {
+    if (isMassageActionDisabled || hasAppliedMassage) {
+      return;
+    }
+
+    applyMutation.mutate();
+  };
+
+  const handleCancelMassage = () => {
+    if (isMassageActionDisabled || !hasAppliedMassage) {
+      return;
+    }
+
+    cancelMutation.mutate();
+  };
 
   return (
     <section className="bg-background-surface flex flex-col gap-6 rounded-2xl p-6">
@@ -40,11 +66,18 @@ export function MassageChairSection() {
 
         <div className="flex w-[330px] shrink-0 flex-col justify-end gap-3">
           <TextButton
-            variant="filled"
+            variant={isMassageActionDisabled ? "disabled" : "filled"}
             size="wide"
-            onClick={() => applyMutation.mutate()}
+            disabled={isMassageActionDisabled}
+            onClick={
+              hasAppliedMassage ? handleCancelMassage : handleApplyMassage
+            }
           >
-            신청하기
+            {isUserLoading
+              ? "확인 중"
+              : hasAppliedMassage
+                ? "취소하기"
+                : "신청하기"}
           </TextButton>
           <p className="text-sub-2 text-caption-2">
             안마의자 신청시간은 20:20 ~ 21:00 입니다

--- a/src/features/self-study/model/useCancelStudy.ts
+++ b/src/features/self-study/model/useCancelStudy.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
+import {
+  dormitoryMutations,
+  dormitoryQueries,
+} from "@/entities/dormitory/api/dormitoryQueries";
+
+export function useCancelStudy() {
+  const queryClient = useQueryClient();
+  const studyQuery = dormitoryQueries.study();
+
+  return useMutation({
+    mutationFn: dormitoryMutations.cancelStudy,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey }),
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.NotFound) {
+        toast.error("자습 신청 내역이 없습니다.");
+        return;
+      }
+
+      toast.error("자습 취소에 실패했습니다.");
+    },
+  });
+}

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -11,6 +11,7 @@ import { userQueries } from "@/entities/user/api/userQueries";
 import { isManagementRole } from "@/entities/user/lib/userRole";
 import { useStudyFilter } from "../model/useStudyFilter";
 import { useApplyStudy } from "../model/useApplyStudy";
+import { useCancelStudy } from "../model/useCancelStudy";
 import { useCheckStudyAttendance } from "../model/useCheckStudyAttendance";
 import { useStudyAttendanceSubscription } from "../model/useStudyAttendanceSubscription";
 import { StudyApplicantCard } from "./StudyApplicantCard";
@@ -26,9 +27,15 @@ export function SelfStudySection() {
   const { searchQuery, selectedGrades, selectedClasses, selectedGender } =
     state;
   const applyMutation = useApplyStudy();
+  const cancelMutation = useCancelStudy();
   const isStudyBanned = user?.isBanned === true;
-  const isApplyDisabled =
-    isUserLoading || isStudyBanned || applyMutation.isPending;
+  const hasAppliedStudy =
+    user !== undefined &&
+    students.some((student) => student.userId === user.id);
+  const isStudyActionPending =
+    applyMutation.isPending || cancelMutation.isPending;
+  const isStudyActionDisabled =
+    isUserLoading || isStudyBanned || isStudyActionPending;
   const canManageStudy = isManagementRole(user?.role);
   const { checkedStudentIds, markChecked } = useStudyAttendanceSubscription(
     user?.role,
@@ -50,11 +57,19 @@ export function SelfStudySection() {
       payload: selectedGender === gender ? null : gender,
     });
   const handleApplyStudy = () => {
-    if (isApplyDisabled) {
+    if (isStudyActionDisabled || hasAppliedStudy) {
       return;
     }
 
     applyMutation.mutate();
+  };
+
+  const handleCancelStudy = () => {
+    if (isStudyActionDisabled || !hasAppliedStudy) {
+      return;
+    }
+
+    cancelMutation.mutate();
   };
 
   const handleCheckAttendance = (studentId: number) => {
@@ -184,19 +199,21 @@ export function SelfStudySection() {
             variant={
               isStudyBanned
                 ? "negative"
-                : isApplyDisabled
+                : isStudyActionDisabled
                   ? "disabled"
                   : "filled"
             }
             size="wide"
-            disabled={isApplyDisabled}
-            onClick={handleApplyStudy}
+            disabled={isStudyActionDisabled}
+            onClick={hasAppliedStudy ? handleCancelStudy : handleApplyStudy}
           >
             {isStudyBanned
               ? "자습 금지를 당했어요!"
               : isUserLoading
                 ? "확인 중"
-                : "신청하기"}
+                : hasAppliedStudy
+                  ? "취소하기"
+                  : "신청하기"}
           </TextButton>
 
           <p className="text-sub-2 text-caption-2">

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -1,4 +1,8 @@
-import axios, { HttpStatusCode } from "axios";
+import axios, { HttpStatusCode, type InternalAxiosRequestConfig } from "axios";
+
+interface RetryableRequestConfig extends InternalAxiosRequestConfig {
+  _retried?: boolean;
+}
 
 export const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -16,6 +20,7 @@ const authPathsWithoutRefresh = [
 ];
 
 let refreshPromise: Promise<string> | null = null;
+let isSessionExpired = false;
 
 instance.interceptors.request.use((config) => {
   if (config.url?.startsWith("/api/")) {
@@ -36,11 +41,12 @@ instance.interceptors.response.use(
   async (error) => {
     if (typeof window === "undefined") return Promise.reject(error);
 
-    const originalRequest = error.config;
+    const originalRequest = error.config as RetryableRequestConfig;
 
     if (
       error.response?.status === HttpStatusCode.Unauthorized &&
       !originalRequest._retried &&
+      !isSessionExpired &&
       !authPathsWithoutRefresh.some((path) =>
         originalRequest.url?.includes(path),
       )
@@ -67,9 +73,11 @@ instance.interceptors.response.use(
         const accessToken = await refreshPromise;
         originalRequest.headers.Authorization = `Bearer ${accessToken}`;
         return instance(originalRequest);
-      } catch {
+      } catch (refreshError) {
+        isSessionExpired = true;
         sessionStorage.removeItem("access_token");
         window.location.href = "/signin";
+        return Promise.reject(refreshError);
       }
     }
 

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -15,7 +15,6 @@ const authPathsWithoutRefresh = [
   "/api/auth/signout",
 ];
 
-const retriedRequests = new WeakSet<object>();
 let refreshPromise: Promise<string> | null = null;
 
 instance.interceptors.request.use((config) => {
@@ -41,10 +40,10 @@ instance.interceptors.response.use(
 
     if (
       error.response?.status === HttpStatusCode.Unauthorized &&
-      !retriedRequests.has(config) &&
+      !config.headers["x-retried"] &&
       !authPathsWithoutRefresh.some((path) => config.url?.includes(path))
     ) {
-      retriedRequests.add(config);
+      config.headers["x-retried"] = "true";
 
       try {
         if (!refreshPromise) {

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -48,17 +48,15 @@ instance.interceptors.response.use(
 
       try {
         if (!refreshPromise) {
-          refreshPromise = axios
-            .post("/api/auth/refresh")
-            .then(({ data }) => {
-              const token = data.data?.accessToken;
-              if (!token) {
-                throw new Error("Access token is missing");
-              }
-              sessionStorage.setItem("access_token", token);
-              refreshPromise = null;
-              return token;
-            });
+          refreshPromise = axios.post("/api/auth/refresh").then(({ data }) => {
+            const token = data.data?.accessToken;
+            if (!token) {
+              throw new Error("Access token is missing");
+            }
+            sessionStorage.setItem("access_token", token);
+            refreshPromise = null;
+            return token;
+          });
         }
 
         const accessToken = await refreshPromise;

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -1,8 +1,4 @@
-import axios, { HttpStatusCode, type InternalAxiosRequestConfig } from "axios";
-
-interface RetryableRequestConfig extends InternalAxiosRequestConfig {
-  _retried?: boolean;
-}
+import axios, { HttpStatusCode } from "axios";
 
 export const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -19,8 +15,8 @@ const authPathsWithoutRefresh = [
   "/api/auth/signout",
 ];
 
+const retriedRequests = new WeakSet<object>();
 let refreshPromise: Promise<string> | null = null;
-let isSessionExpired = false;
 
 instance.interceptors.request.use((config) => {
   if (config.url?.startsWith("/api/")) {
@@ -41,17 +37,14 @@ instance.interceptors.response.use(
   async (error) => {
     if (typeof window === "undefined") return Promise.reject(error);
 
-    const originalRequest = error.config as RetryableRequestConfig;
+    const config = error.config;
 
     if (
       error.response?.status === HttpStatusCode.Unauthorized &&
-      !originalRequest._retried &&
-      !isSessionExpired &&
-      !authPathsWithoutRefresh.some((path) =>
-        originalRequest.url?.includes(path),
-      )
+      !retriedRequests.has(config) &&
+      !authPathsWithoutRefresh.some((path) => config.url?.includes(path))
     ) {
-      originalRequest._retried = true;
+      retriedRequests.add(config);
 
       try {
         if (!refreshPromise) {
@@ -63,18 +56,15 @@ instance.interceptors.response.use(
                 throw new Error("Access token is missing");
               }
               sessionStorage.setItem("access_token", token);
-              return token;
-            })
-            .finally(() => {
               refreshPromise = null;
+              return token;
             });
         }
 
         const accessToken = await refreshPromise;
-        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-        return instance(originalRequest);
+        config.headers.Authorization = `Bearer ${accessToken}`;
+        return instance(config);
       } catch (refreshError) {
-        isSessionExpired = true;
         sessionStorage.removeItem("access_token");
         window.location.href = "/signin";
         return Promise.reject(refreshError);

--- a/src/widgets/main/ui/MassageApplyCard.tsx
+++ b/src/widgets/main/ui/MassageApplyCard.tsx
@@ -3,7 +3,9 @@
 import { useQuery } from "@tanstack/react-query";
 import ChairIcon from "@/shared/asset/svg/Chair";
 import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
+import { userQueries } from "@/entities/user/api/userQueries";
 import { useApplyMassage } from "@/features/massage-chair/model/useApplyMassage";
+import { useCancelMassage } from "@/features/massage-chair/model/useCancelMassage";
 import ApplyCard from "./ApplyCard";
 
 const MASSAGE_MAX = 5;
@@ -11,7 +13,31 @@ const MASSAGE_MAX = 5;
 export default function MassageApplyCard() {
   const massageQuery = dormitoryQueries.massage();
   const { data: applicants = [] } = useQuery(massageQuery);
+  const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const applyMutation = useApplyMassage();
+  const cancelMutation = useCancelMassage();
+  const hasAppliedMassage =
+    user !== undefined &&
+    applicants.some((student) => student.studentNumber === user.studentNumber);
+  const isMassageActionPending =
+    applyMutation.isPending || cancelMutation.isPending;
+  const isMassageActionDisabled = isUserLoading || isMassageActionPending;
+
+  const handleApplyMassage = () => {
+    if (isMassageActionDisabled || hasAppliedMassage) {
+      return;
+    }
+
+    applyMutation.mutate();
+  };
+
+  const handleCancelMassage = () => {
+    if (isMassageActionDisabled || !hasAppliedMassage) {
+      return;
+    }
+
+    cancelMutation.mutate();
+  };
 
   return (
     <ApplyCard
@@ -20,10 +46,13 @@ export default function MassageApplyCard() {
       current={applicants.length}
       total={MASSAGE_MAX}
       timeText="안마 의자 신청 시간은 20:20 ~ 21:00에 신청이 가능해요"
-      buttonText="신청"
+      buttonText={
+        isUserLoading ? "확인 중" : hasAppliedMassage ? "취소" : "신청"
+      }
       detailHref="/dormitory"
       femaleNotice
-      onApply={() => applyMutation.mutate()}
+      disabled={isMassageActionDisabled}
+      onApply={hasAppliedMassage ? handleCancelMassage : handleApplyMassage}
     />
   );
 }

--- a/src/widgets/main/ui/StudyApplyCard.tsx
+++ b/src/widgets/main/ui/StudyApplyCard.tsx
@@ -5,6 +5,7 @@ import BookIcon from "@/shared/asset/svg/ApplyStudy";
 import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
 import { userQueries } from "@/entities/user/api/userQueries";
 import { useApplyStudy } from "@/features/self-study/model/useApplyStudy";
+import { useCancelStudy } from "@/features/self-study/model/useCancelStudy";
 import ApplyCard from "./ApplyCard";
 
 const STUDY_MAX = 50;
@@ -14,16 +15,30 @@ export default function StudyApplyCard() {
   const { data: students = [] } = useQuery(studyQuery);
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const applyMutation = useApplyStudy();
+  const cancelMutation = useCancelStudy();
   const isStudyBanned = user?.isBanned === true;
-  const isApplyDisabled =
-    isUserLoading || isStudyBanned || applyMutation.isPending;
+  const hasAppliedStudy =
+    user !== undefined &&
+    students.some((student) => student.userId === user.id);
+  const isStudyActionPending =
+    applyMutation.isPending || cancelMutation.isPending;
+  const isStudyActionDisabled =
+    isUserLoading || isStudyBanned || isStudyActionPending;
 
   const handleApplyStudy = () => {
-    if (isApplyDisabled) {
+    if (isStudyActionDisabled || hasAppliedStudy) {
       return;
     }
 
     applyMutation.mutate();
+  };
+
+  const handleCancelStudy = () => {
+    if (isStudyActionDisabled || !hasAppliedStudy) {
+      return;
+    }
+
+    cancelMutation.mutate();
   };
 
   return (
@@ -38,13 +53,15 @@ export default function StudyApplyCard() {
           ? "자습 금지를 당했어요!"
           : isUserLoading
             ? "확인 중"
-            : "신청"
+            : hasAppliedStudy
+              ? "취소"
+              : "신청"
       }
       buttonVariant={isStudyBanned ? "negative" : "filled"}
       buttonSize={isStudyBanned ? "fit" : "small"}
       detailHref="/dormitory"
-      disabled={isApplyDisabled}
-      onApply={handleApplyStudy}
+      disabled={isStudyActionDisabled}
+      onApply={hasAppliedStudy ? handleCancelStudy : handleApplyStudy}
     />
   );
 }

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -73,12 +73,12 @@ function TimeTableCardLoading() {
 
 function TimeTableCardError({ resetErrorBoundary }: QueryErrorFallbackProps) {
   return (
-    <div className="bg-background-surface flex h-[140px] w-full flex-col rounded-2xl p-6 2xl:h-[354px]">
-      <div className="mb-4 flex items-center gap-1">
+    <div className="bg-background-surface flex h-[140px] w-full flex-col overflow-hidden rounded-2xl p-6 2xl:h-[354px]">
+      <div className="mb-2 flex items-center gap-1">
         <Calendar />
         <span className="text-text-1 text-main-text font-semibold">시간표</span>
       </div>
-      <div className="flex flex-1 flex-col items-center justify-center gap-3">
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3">
         <span className="text-text-3 text-negative font-medium">
           시간표를 불러오지 못했습니다.
         </span>


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 자습 신청과 안마의자 신청의 취소 UI를 실제 취소 API 흐름에 연결했습니다.
- 메인 카드와 신청 섹션에서 취소 가능 상태, 버튼 동작, 신청 상태 표시를 함께 갱신했습니다.
- 인증 갱신 실패 시 세션 만료로 처리되도록 수정하고, 토큰 리프레시 재시도 추적 방식을 헤더 마커 기반으로 정리했습니다.
- 오류 상태 UI와 콜백 페이지 로그인 버튼 크기를 개선했습니다.
- 릴리즈 PR 버전 검증 CI를 추가하고, Discord PR 알림 멘션 형식을 수정했습니다.