### PR TITLE
fix: opening-status 403 오류가 동아리 목록 에러 폴백으로 전파되는 문제 수정

### DIFF
--- a/src/features/club/ui/ClubSection.tsx
+++ b/src/features/club/ui/ClubSection.tsx
@@ -2,7 +2,11 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import Club from "@/shared/asset/svg/Club";
 import Back from "@/shared/asset/svg/Back";
 import Smile from "@/shared/asset/svg/Smile";
@@ -106,7 +110,7 @@ const ClubSection = () => {
 
   const { data } = useSuspenseQuery(clubQueries.list());
   const { data: user } = useSuspenseQuery(userQueries.me());
-  const { data: isRegistrationPeriod = false } = useSuspenseQuery(
+  const { data: isRegistrationPeriod = false } = useQuery(
     clubQueries.openingStatus(),
   );
   const isManager = user.role === "ADMIN" || user.role === "STUDENT_COUNCIL";


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

`ClubSection`에서 `clubQueries.openingStatus()`를 `useSuspenseQuery`로 호출하면, `/clubs/opening-status` 엔드포인트가 403을 반환할 경우 에러가 `ClientQueryBoundary`로 전파되어 동아리 목록 전체가 에러 폴백("동아리 목록을 불러오지 못했어요")으로 대체되는 문제가 있었습니다.

**원인**
- `DORMITORY_MANAGER` 등 동아리 개설 신청 권한이 없는 역할이 `/clubs/opening-status`에 접근하면 서버가 403 반환
- `useSuspenseQuery`는 에러 발생 시 상위 Error Boundary로 throw하는 것이 기본 동작
- 결과적으로 개설 신청 기간 여부를 결정하는 쿼리 실패가 동아리 목록까지 함께 날리는 문제 발생

**수정**
- `clubQueries.openingStatus()` 호출을 `useSuspenseQuery` → `useQuery`로 변경
- `useQuery`는 기본적으로 에러를 Error Boundary로 전파하지 않으므로, 403 응답 시 동아리 목록이 정상 노출됨

<img width="1393" height="718" alt="image" src="https://github.com/user-attachments/assets/415eab02-8ffb-426a-99de-45f3d0edaf83" />


## 💬리뷰 요구사항(선택)

`openingStatus` 쿼리만 `useQuery`로 분리했을 때, 다른 두 `useSuspenseQuery`가 resolve된 후 이 쿼리가 뒤늦게 resolve될 경우 등록 폼이 잠깐 숨겨졌다가 나타날 수 있습니다.