### PR TITLE
chore: 날짜 기반 릴리즈 식별자 적용

### DIFF
--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -10,6 +10,9 @@ Analyze the changes below, draft a PR title and body, then create the PR using G
 
 Current branch: !`git branch --show-current`
 
+Current KST release ID:
+!`TZ=Asia/Seoul date '+v%Y.%m%d.%H%M'`
+
 Commits since develop:
 !`git log --oneline develop..HEAD`
 
@@ -27,12 +30,15 @@ The PR type is determined by the title format.
 
 | Title Format                                | Base Branch | Condition                                     |
 | ------------------------------------------- | ----------- | --------------------------------------------- |
-| `v0.0.0` (version)                          | `main`      | Only allowed when current branch is `develop` |
+| `vYYYY.MMDD.HHmm` (release ID)              | `main`      | Only allowed when current branch is `develop` |
 | `feat:`, `fix:`, etc. (conventional commit) | `develop`   | Allowed from any feature branch               |
 
-**Release PR rules** (`v0.0.0` format):
+**Release PR rules** (`vYYYY.MMDD.HHmm` format):
 
 - Must be created from the `develop` branch only.
+- Use the current Korea Standard Time (Asia/Seoul) to generate the release ID.
+- Release IDs are GitHub PR/tag/release identifiers only.
+- Do not update or compare `package.json` / `package-lock.json` versions for release PRs.
 - If the current branch is not `develop`, print an error message and abort.
 
 ## Title Rules
@@ -41,8 +47,8 @@ The PR type is determined by the title format.
   - Types: `feat`, `fix`, `refactor`, `change`, `remove`, `docs`, `chore`
   - Match type to branch prefix (e.g. `feat/xxx` → `feat:`)
   - Example: `feat: 기숙사 자습 신청 및 취소 기능 추가`
-- **Release PR**: `v<major>.<minor>.<patch>` format
-  - Example: `v1.2.0`
+- **Release PR**: `vYYYY.MMDD.HHmm` format
+  - Example: `v2026.0510.0109`
 
 ## Body Structure
 
@@ -78,7 +84,10 @@ Follow the org PR template (`team-incube/.github`). Omit reviewer assignment, la
 
 1. Finalize the **Title** and **Body**.
 2. Determine the base branch:
-   - If the title starts with `v` followed by a digit → `main` (verify current branch is `develop`)
+   - If the current branch is `develop`, create a release PR:
+     - Title: current KST release ID in `vYYYY.MMDD.HHmm` format
+     - Base: `main`
+   - If the title matches `^v[0-9]{4}\.[0-9]{4}\.[0-9]{4}$` → `main` (verify current branch is `develop`)
    - Otherwise → `develop`
 3. Create the PR directly using **GitHub MCP** (`mcp__github__create_pull_request`):
    - `owner`: `team-incube`

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -84,11 +84,10 @@ Follow the org PR template (`team-incube/.github`). Omit reviewer assignment, la
 
 1. Finalize the **Title** and **Body**.
 2. Determine the base branch:
-   - If the current branch is `develop`, create a release PR:
-     - Title: current KST release ID in `vYYYY.MMDD.HHmm` format
-     - Base: `main`
-   - If the title matches `^v[0-9]{4}\.[0-9]{4}\.[0-9]{4}$` → `main` (verify current branch is `develop`)
-   - Otherwise → `develop`
+   - If the current branch is develop, create a release PR:
+     - Title: current KST release ID in vYYYY.MMDD.HHmm format
+     - Base: main
+   - Otherwise → develop
 3. Create the PR directly using **GitHub MCP** (`mcp__github__create_pull_request`):
    - `owner`: `team-incube`
    - `repo`: `Flooding-Client-V2`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,42 +7,22 @@ on:
 
 jobs:
   # ─────────────────────────────────────────────
-  # 0. develop → main 릴리즈 PR 버전 검사
+  # 0. develop → main 릴리즈 PR 식별자 검사
   # ─────────────────────────────────────────────
   release-version-check:
-    name: Release Version Check
+    name: Release ID Check
     runs-on: ubuntu-latest
     if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop'
     steps:
       - uses: actions/checkout@v4
 
-      - name: PR 제목 및 package 버전 검사
+      - name: 릴리즈 PR 제목 검사
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ ! "$PR_TITLE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "develop → main PR 제목은 vX.Y.Z 형식이어야 합니다. 예: v0.2.2"
+          if [[ ! "$PR_TITLE" =~ ^v[0-9]{4}\.[0-9]{4}\.[0-9]{4}$ ]]; then
+            echo "develop → main PR 제목은 vYYYY.MMDD.HHmm 형식이어야 합니다. 예: v2026.0510.0109"
             echo "현재 PR 제목: $PR_TITLE"
-            exit 1
-          fi
-
-          RELEASE_VERSION="${PR_TITLE#v}"
-          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          LOCKFILE_VERSION="$(node -p "require('./package-lock.json').version")"
-          LOCKFILE_ROOT_VERSION="$(node -p "require('./package-lock.json').packages[''].version")"
-
-          if [[ "$PACKAGE_VERSION" != "$RELEASE_VERSION" ]]; then
-            echo "package.json version이 PR 제목 버전과 일치해야 합니다."
-            echo "PR 제목 버전: $RELEASE_VERSION"
-            echo "package.json version: $PACKAGE_VERSION"
-            exit 1
-          fi
-
-          if [[ "$LOCKFILE_VERSION" != "$RELEASE_VERSION" || "$LOCKFILE_ROOT_VERSION" != "$RELEASE_VERSION" ]]; then
-            echo "package-lock.json version이 PR 제목 버전과 일치해야 합니다."
-            echo "PR 제목 버전: $RELEASE_VERSION"
-            echo "package-lock.json version: $LOCKFILE_VERSION"
-            echo "package-lock.json packages[''].version: $LOCKFILE_ROOT_VERSION"
             exit 1
           fi
 


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

메이저 버전이 2로 정해져 있는 상황에서 마이너 버전과 패치 버전만으로는 버전 관리가 어렵고 `develop` to `main` 머지 작업에서 버전 관리를 진행하는 것보다 릴리즈 노트에서 버전 관리를 하는 것이 타당하다고 생각되어 작업을 진행하였습니다.

또 클라이언트 특성 상 핫픽스 작업이 많을 것으로 판단되어 시간과 분까지 PR 제목 규칙에 포함하였습니다.

- `develop` → `main` 릴리즈 PR 제목 검증을 `vYYYY.MMDD.HHmm` 형식으로 변경했습니다.
- 릴리즈 PR에서 `package.json` / `package-lock.json` 버전 일치 검증을 제거했습니다.
- PR 생성 스킬의 릴리즈 규칙을 한국시간 기준 날짜 기반 식별자로 갱신했습니다.
- 기존 릴리즈 PR의 제목을 해당 규칙대로 변경하였습니다.

<img width="512" height="294" alt="image" src="https://github.com/user-attachments/assets/a47a2cc9-dc7b-4de0-b435-6032f7f43b5e" />
