### PR TITLE
v2026.0510.1328

### DIFF
--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -10,6 +10,9 @@ Analyze the changes below, draft a PR title and body, then create the PR using G
 
 Current branch: !`git branch --show-current`
 
+Current KST release ID:
+!`TZ=Asia/Seoul date '+v%Y.%m%d.%H%M'`
+
 Commits since develop:
 !`git log --oneline develop..HEAD`
 
@@ -27,12 +30,15 @@ The PR type is determined by the title format.
 
 | Title Format                                | Base Branch | Condition                                     |
 | ------------------------------------------- | ----------- | --------------------------------------------- |
-| `v0.0.0` (version)                          | `main`      | Only allowed when current branch is `develop` |
+| `vYYYY.MMDD.HHmm` (release ID)              | `main`      | Only allowed when current branch is `develop` |
 | `feat:`, `fix:`, etc. (conventional commit) | `develop`   | Allowed from any feature branch               |
 
-**Release PR rules** (`v0.0.0` format):
+**Release PR rules** (`vYYYY.MMDD.HHmm` format):
 
 - Must be created from the `develop` branch only.
+- Use the current Korea Standard Time (Asia/Seoul) to generate the release ID.
+- Release IDs are GitHub PR/tag/release identifiers only.
+- Do not update or compare `package.json` / `package-lock.json` versions for release PRs.
 - If the current branch is not `develop`, print an error message and abort.
 
 ## Title Rules
@@ -41,8 +47,8 @@ The PR type is determined by the title format.
   - Types: `feat`, `fix`, `refactor`, `change`, `remove`, `docs`, `chore`
   - Match type to branch prefix (e.g. `feat/xxx` → `feat:`)
   - Example: `feat: 기숙사 자습 신청 및 취소 기능 추가`
-- **Release PR**: `v<major>.<minor>.<patch>` format
-  - Example: `v1.2.0`
+- **Release PR**: `vYYYY.MMDD.HHmm` format
+  - Example: `v2026.0510.0109`
 
 ## Body Structure
 
@@ -78,7 +84,10 @@ Follow the org PR template (`team-incube/.github`). Omit reviewer assignment, la
 
 1. Finalize the **Title** and **Body**.
 2. Determine the base branch:
-   - If the title starts with `v` followed by a digit → `main` (verify current branch is `develop`)
+   - If the current branch is `develop`, create a release PR:
+     - Title: current KST release ID in `vYYYY.MMDD.HHmm` format
+     - Base: `main`
+   - If the title matches `^v[0-9]{4}\.[0-9]{4}\.[0-9]{4}$` → `main` (verify current branch is `develop`)
    - Otherwise → `develop`
 3. Create the PR directly using **GitHub MCP** (`mcp__github__create_pull_request`):
    - `owner`: `team-incube`

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -84,11 +84,10 @@ Follow the org PR template (`team-incube/.github`). Omit reviewer assignment, la
 
 1. Finalize the **Title** and **Body**.
 2. Determine the base branch:
-   - If the current branch is `develop`, create a release PR:
-     - Title: current KST release ID in `vYYYY.MMDD.HHmm` format
-     - Base: `main`
-   - If the title matches `^v[0-9]{4}\.[0-9]{4}\.[0-9]{4}$` → `main` (verify current branch is `develop`)
-   - Otherwise → `develop`
+   - If the current branch is develop, create a release PR:
+     - Title: current KST release ID in vYYYY.MMDD.HHmm format
+     - Base: main
+   - Otherwise → develop
 3. Create the PR directly using **GitHub MCP** (`mcp__github__create_pull_request`):
    - `owner`: `team-incube`
    - `repo`: `Flooding-Client-V2`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,42 +7,22 @@ on:
 
 jobs:
   # ─────────────────────────────────────────────
-  # 0. develop → main 릴리즈 PR 버전 검사
+  # 0. develop → main 릴리즈 PR 식별자 검사
   # ─────────────────────────────────────────────
   release-version-check:
-    name: Release Version Check
+    name: Release ID Check
     runs-on: ubuntu-latest
     if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop'
     steps:
       - uses: actions/checkout@v4
 
-      - name: PR 제목 및 package 버전 검사
+      - name: 릴리즈 PR 제목 검사
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ ! "$PR_TITLE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "develop → main PR 제목은 vX.Y.Z 형식이어야 합니다. 예: v0.2.2"
+          if [[ ! "$PR_TITLE" =~ ^v[0-9]{4}\.[0-9]{4}\.[0-9]{4}$ ]]; then
+            echo "develop → main PR 제목은 vYYYY.MMDD.HHmm 형식이어야 합니다. 예: v2026.0510.0109"
             echo "현재 PR 제목: $PR_TITLE"
-            exit 1
-          fi
-
-          RELEASE_VERSION="${PR_TITLE#v}"
-          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          LOCKFILE_VERSION="$(node -p "require('./package-lock.json').version")"
-          LOCKFILE_ROOT_VERSION="$(node -p "require('./package-lock.json').packages[''].version")"
-
-          if [[ "$PACKAGE_VERSION" != "$RELEASE_VERSION" ]]; then
-            echo "package.json version이 PR 제목 버전과 일치해야 합니다."
-            echo "PR 제목 버전: $RELEASE_VERSION"
-            echo "package.json version: $PACKAGE_VERSION"
-            exit 1
-          fi
-
-          if [[ "$LOCKFILE_VERSION" != "$RELEASE_VERSION" || "$LOCKFILE_ROOT_VERSION" != "$RELEASE_VERSION" ]]; then
-            echo "package-lock.json version이 PR 제목 버전과 일치해야 합니다."
-            echo "PR 제목 버전: $RELEASE_VERSION"
-            echo "package-lock.json version: $LOCKFILE_VERSION"
-            echo "package-lock.json packages[''].version: $LOCKFILE_ROOT_VERSION"
             exit 1
           fi
 

--- a/src/features/club/ui/ClubSection.tsx
+++ b/src/features/club/ui/ClubSection.tsx
@@ -2,7 +2,11 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import Club from "@/shared/asset/svg/Club";
 import Back from "@/shared/asset/svg/Back";
 import Smile from "@/shared/asset/svg/Smile";
@@ -106,7 +110,7 @@ const ClubSection = () => {
 
   const { data } = useSuspenseQuery(clubQueries.list());
   const { data: user } = useSuspenseQuery(userQueries.me());
-  const { data: isRegistrationPeriod = false } = useSuspenseQuery(
+  const { data: isRegistrationPeriod = false } = useQuery(
     clubQueries.openingStatus(),
   );
   const isManager = user.role === "ADMIN" || user.role === "STUDENT_COUNCIL";


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- #91 `opening-status` 403 오류가 동아리 목록 전체 에러 폴백으로 전파되지 않도록 조회 방식을 조정했습니다.
- #93 릴리즈 PR 제목 규칙을 한국시간 기준 `vYYYY.MMDD.HHmm` 형식으로 변경했습니다.
- #93 릴리즈 PR 검증에서 `package.json` / `package-lock.json` 버전 일치 검사를 제거했습니다.
- #93 PR 생성 스킬의 릴리즈 규칙과 본문 생성 기준을 날짜 기반 릴리즈 식별자 방식으로 갱신했습니다.