### PR TITLE
feat: 자습 금지 해제 기능 및 검색 디바운싱 추가

### DIFF
--- a/src/entities/dormitory/api/dormitoryQueries.ts
+++ b/src/entities/dormitory/api/dormitoryQueries.ts
@@ -86,6 +86,9 @@ export const dormitoryMutations = {
   banStudy: (userId: number) =>
     instance.post(`/dormitory/studies/ban/${userId}`),
 
+  unbanStudy: (userId: number) =>
+    instance.delete(`/dormitory/studies/ban/${userId}`),
+
   checkStudyAttendance: (userId: number) =>
     instance.post(`/dormitory/studies/attendance/${userId}`),
 

--- a/src/features/self-study/model/useUnbanStudy.ts
+++ b/src/features/self-study/model/useUnbanStudy.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
+import {
+  dormitoryMutations,
+  dormitoryQueries,
+} from "@/entities/dormitory/api/dormitoryQueries";
+import type { SearchUsersPage } from "@/entities/user/model/user";
+
+interface UnbanStudyResult {
+  successfulStudentIds: number[];
+  failedCount: number;
+}
+
+export function useUnbanStudy() {
+  const queryClient = useQueryClient();
+  const studyQuery = dormitoryQueries.study();
+
+  return useMutation({
+    mutationFn: async (studentIds: number[]): Promise<UnbanStudyResult> => {
+      const results = await Promise.allSettled(
+        studentIds.map(dormitoryMutations.unbanStudy),
+      );
+      const successfulStudentIds = studentIds.filter(
+        (_, index) => results[index].status === "fulfilled",
+      );
+      const failedResult = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+
+      if (successfulStudentIds.length === 0 && failedResult) {
+        throw failedResult.reason;
+      }
+
+      return {
+        successfulStudentIds,
+        failedCount: studentIds.length - successfulStudentIds.length,
+      };
+    },
+    onMutate: async (studentIds) => {
+      await queryClient.cancelQueries({ queryKey: ["user", "list"] });
+      const previousData = queryClient.getQueriesData<SearchUsersPage>({
+        queryKey: ["user", "list"],
+      });
+      queryClient.setQueriesData<SearchUsersPage>(
+        { queryKey: ["user", "list"] },
+        (current) => {
+          if (!current) return current;
+          return {
+            ...current,
+            content: current.content.map((student) =>
+              studentIds.includes(student.id)
+                ? { ...student, isBanned: false }
+                : student,
+            ),
+          };
+        },
+      );
+      return { previousData };
+    },
+    onSuccess: ({ successfulStudentIds, failedCount }) => {
+      if (failedCount > 0) {
+        toast.warning(
+          `${successfulStudentIds.length}명은 자습 금지를 해제했고, ${failedCount}명은 실패했습니다.`,
+        );
+        return;
+      }
+
+      toast.success(
+        `${successfulStudentIds.length}명의 자습 금지를 해제했습니다.`,
+      );
+    },
+    onError: (error, _studentIds, context) => {
+      context?.previousData.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.NotFound) {
+        toast.error("존재하지 않는 학생이거나 자습 금지 상태가 아닙니다.");
+        return;
+      }
+
+      toast.error("자습 금지 해제에 실패했습니다.");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey });
+      queryClient.invalidateQueries({ queryKey: ["user", "list"] });
+    },
+  });
+}

--- a/src/features/self-study/model/useUnbanStudy.ts
+++ b/src/features/self-study/model/useUnbanStudy.ts
@@ -91,7 +91,7 @@ export function useUnbanStudy() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: studyQuery.queryKey });
-      queryClient.invalidateQueries({ queryKey: ["user", "list"] });
+      queryClient.invalidateQueries({ queryKey: userQueries.list().queryKey });
     },
   });
 }

--- a/src/features/self-study/model/useUnbanStudy.ts
+++ b/src/features/self-study/model/useUnbanStudy.ts
@@ -41,12 +41,12 @@ export function useUnbanStudy() {
       };
     },
     onMutate: async (studentIds) => {
-      await queryClient.cancelQueries({ queryKey: ["user", "list"] });
+      await queryClient.cancelQueries({ queryKey: userQueries.list().queryKey });
       const previousData = queryClient.getQueriesData<SearchUsersPage>({
-        queryKey: ["user", "list"],
+        queryKey: userQueries.list().queryKey,
       });
       queryClient.setQueriesData<SearchUsersPage>(
-        { queryKey: ["user", "list"] },
+        { queryKey: userQueries.list().queryKey },
         (current) => {
           if (!current) return current;
           return {

--- a/src/features/self-study/model/useUnbanStudy.ts
+++ b/src/features/self-study/model/useUnbanStudy.ts
@@ -8,6 +8,7 @@ import {
   dormitoryQueries,
 } from "@/entities/dormitory/api/dormitoryQueries";
 import type { SearchUsersPage } from "@/entities/user/model/user";
+import { userQueries } from "@/entities/user/api/userQueries";
 
 interface UnbanStudyResult {
   successfulStudentIds: number[];
@@ -41,7 +42,9 @@ export function useUnbanStudy() {
       };
     },
     onMutate: async (studentIds) => {
-      await queryClient.cancelQueries({ queryKey: userQueries.list().queryKey });
+      await queryClient.cancelQueries({
+        queryKey: userQueries.list().queryKey,
+      });
       const previousData = queryClient.getQueriesData<SearchUsersPage>({
         queryKey: userQueries.list().queryKey,
       });

--- a/src/features/self-study/ui/StudentManagementSection.tsx
+++ b/src/features/self-study/ui/StudentManagementSection.tsx
@@ -149,9 +149,7 @@ const StudentManagementSection = () => {
     bannedStudentIdSet.has(studentId);
 
   const getSelectedBanTargetIds = () =>
-    selectedStudentIds.filter(
-      (studentId) => !isStudyBanned(studentId),
-    );
+    selectedStudentIds.filter((studentId) => !isStudyBanned(studentId));
 
   const getSelectedUnbanTargetIds = () =>
     selectedStudentIds.filter(isStudyBanned);

--- a/src/features/self-study/ui/StudentManagementSection.tsx
+++ b/src/features/self-study/ui/StudentManagementSection.tsx
@@ -13,6 +13,7 @@ import {
   type StudyBanFilter,
 } from "@/features/self-study/lib/filterManagedStudents";
 import { useBanStudy } from "@/features/self-study/model/useBanStudy";
+import { useUnbanStudy } from "@/features/self-study/model/useUnbanStudy";
 import { ManagedStudentCard } from "./ManagedStudentCard";
 import { StudentManagementFilterPanel } from "./StudentManagementFilterPanel";
 import { StudyBanActionPanel } from "./StudyBanActionPanel";
@@ -68,6 +69,7 @@ function StudentManagementSectionEmpty() {
 const StudentManagementSection = () => {
   const { data: studentPage } = useSuspenseQuery(userQueries.list());
   const banStudyMutation = useBanStudy();
+  const unbanStudyMutation = useUnbanStudy();
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedGrades, setSelectedGrades] = useState<number[]>([]);
   const [selectedClasses, setSelectedClasses] = useState<number[]>([]);
@@ -125,6 +127,7 @@ const StudentManagementSection = () => {
     filter: Exclude<StudyBanFilter, null>,
   ) => {
     setSelectedStudyBanFilter((prev) => (prev === filter ? null : filter));
+    setSelectedStudentIds([]);
   };
 
   const handleToggleStudentSelect = (studentId: number) => {
@@ -138,10 +141,16 @@ const StudentManagementSection = () => {
   const isStudyBanned = (studentId: number) =>
     bannedStudentIdSet.has(studentId);
 
-  const handleBanSelectedStudent = () => {
-    const targetStudentIds = selectedStudentIds.filter(
+  const getSelectedBanTargetIds = () =>
+    selectedStudentIds.filter(
       (studentId) => !isStudyBanned(studentId),
     );
+
+  const getSelectedUnbanTargetIds = () =>
+    selectedStudentIds.filter(isStudyBanned);
+
+  const handleBanSelectedStudent = () => {
+    const targetStudentIds = getSelectedBanTargetIds();
 
     if (targetStudentIds.length === 0) {
       return;
@@ -151,9 +160,22 @@ const StudentManagementSection = () => {
     banStudyMutation.mutate(targetStudentIds);
   };
 
-  const selectedBanTargetCount = selectedStudentIds.filter(
-    (studentId) => !isStudyBanned(studentId),
-  ).length;
+  const handleUnbanSelectedStudent = () => {
+    const targetStudentIds = getSelectedUnbanTargetIds();
+
+    if (targetStudentIds.length === 0) {
+      return;
+    }
+
+    setSelectedStudentIds([]);
+    unbanStudyMutation.mutate(targetStudentIds);
+  };
+
+  const selectedBanTargetCount = getSelectedBanTargetIds().length;
+  const selectedUnbanTargetCount =
+    selectedStudentIds.length - selectedBanTargetCount;
+  const isStudyBanActionPending =
+    banStudyMutation.isPending || unbanStudyMutation.isPending;
 
   return (
     <section className="bg-background-surface flex flex-col gap-4 rounded-2xl p-6 shadow-[0_0_12px_rgba(0,0,0,0.04)]">
@@ -205,10 +227,12 @@ const StudentManagementSection = () => {
           />
 
           <StudyBanActionPanel
+            selectedStudyBanFilter={selectedStudyBanFilter}
             selectedBanTargetCount={selectedBanTargetCount}
-            isPending={banStudyMutation.isPending}
-            onClearSelection={() => setSelectedStudentIds([])}
+            selectedUnbanTargetCount={selectedUnbanTargetCount}
+            isPending={isStudyBanActionPending}
             onBanSelectedStudent={handleBanSelectedStudent}
+            onUnbanSelectedStudent={handleUnbanSelectedStudent}
           />
         </aside>
       </div>

--- a/src/features/self-study/ui/StudentManagementSection.tsx
+++ b/src/features/self-study/ui/StudentManagementSection.tsx
@@ -236,6 +236,7 @@ const StudentManagementSection = () => {
             selectedBanTargetCount={selectedBanTargetCount}
             selectedUnbanTargetCount={selectedUnbanTargetCount}
             isPending={isStudyBanActionPending}
+            onClearSelection={() => setSelectedStudentIds([])}
             onBanSelectedStudent={handleBanSelectedStudent}
             onUnbanSelectedStudent={handleUnbanSelectedStudent}
           />

--- a/src/features/self-study/ui/StudentManagementSection.tsx
+++ b/src/features/self-study/ui/StudentManagementSection.tsx
@@ -5,6 +5,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { userQueries } from "@/entities/user/api/userQueries";
 import type { Sex } from "@/entities/user/model/user";
 import Student from "@/shared/asset/svg/Student";
+import { useDebouncedValue } from "@/shared/lib/useDebouncedValue";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import type { QueryErrorFallbackProps } from "@/shared/ui/QueryErrorBoundary";
 import { Skeleton } from "@/shared/ui/Skeleton";
@@ -17,6 +18,8 @@ import { useUnbanStudy } from "@/features/self-study/model/useUnbanStudy";
 import { ManagedStudentCard } from "./ManagedStudentCard";
 import { StudentManagementFilterPanel } from "./StudentManagementFilterPanel";
 import { StudyBanActionPanel } from "./StudyBanActionPanel";
+
+const SEARCH_DEBOUNCE_DELAY = 300;
 
 function StudentManagementSectionLoading() {
   return (
@@ -60,7 +63,7 @@ function StudentManagementSectionError({
 
 function StudentManagementSectionEmpty() {
   return (
-    <div className="border-sub-3 bg-background flex h-[320px] w-full items-center justify-center rounded-2xl border border-dashed">
+    <div className="flex h-[320px] w-full items-center justify-center">
       <p className="text-text-2 text-sub-1">표시할 학생이 없습니다.</p>
     </div>
   );
@@ -71,6 +74,10 @@ const StudentManagementSection = () => {
   const banStudyMutation = useBanStudy();
   const unbanStudyMutation = useUnbanStudy();
   const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebouncedValue(
+    searchQuery,
+    SEARCH_DEBOUNCE_DELAY,
+  );
   const [selectedGrades, setSelectedGrades] = useState<number[]>([]);
   const [selectedClasses, setSelectedClasses] = useState<number[]>([]);
   const [selectedGender, setSelectedGender] = useState<Sex | null>(null);
@@ -84,7 +91,7 @@ const StudentManagementSection = () => {
 
   const filteredStudents = filterManagedStudents({
     students,
-    searchQuery,
+    searchQuery: debouncedSearchQuery,
     selectedGrades,
     selectedClasses,
     selectedGender,

--- a/src/features/self-study/ui/StudyBanActionPanel.tsx
+++ b/src/features/self-study/ui/StudyBanActionPanel.tsx
@@ -1,41 +1,60 @@
 "use client";
 
 import { TextButton } from "@/shared/ui/Button/TextButton";
+import type { StudyBanFilter } from "@/features/self-study/lib/filterManagedStudents";
 
 interface StudyBanActionPanelProps {
+  selectedStudyBanFilter: StudyBanFilter;
   selectedBanTargetCount: number;
+  selectedUnbanTargetCount: number;
   isPending: boolean;
-  onClearSelection: () => void;
   onBanSelectedStudent: () => void;
+  onUnbanSelectedStudent: () => void;
 }
 
 export function StudyBanActionPanel({
+  selectedStudyBanFilter,
   selectedBanTargetCount,
+  selectedUnbanTargetCount,
   isPending,
-  onClearSelection,
   onBanSelectedStudent,
+  onUnbanSelectedStudent,
 }: StudyBanActionPanelProps) {
+  if (!selectedStudyBanFilter) {
+    return (
+      <p className="text-caption-3 text-sub-1 font-medium">
+        자습 허용/금지 중 하나를 선택해야 자습 금지/해제가 가능해요.
+      </p>
+    );
+  }
+
+  const isAllowedFilterSelected = selectedStudyBanFilter === "ALLOWED";
+  const canBan = selectedBanTargetCount > 0;
+  const canUnban = selectedUnbanTargetCount > 0;
+  const actionTitle = isAllowedFilterSelected ? "자습 금지" : "자습 금지 해제";
+  const isActionEnabled =
+    !isPending && (isAllowedFilterSelected ? canBan : canUnban);
+
   return (
-    <div className="flex flex-col gap-[35px]">
-      <div className="flex items-end justify-between">
-        <span className="text-main-text text-text-1">자습 금지</span>
-        <button
-          type="button"
-          onClick={onClearSelection}
-          className="text-text-4 text-sub-1 hover:text-p-1 cursor-pointer transition-colors"
+    <div className="flex flex-col gap-[24px]">
+      <span className="text-main-text text-text-1">{actionTitle}</span>
+      {isAllowedFilterSelected ? (
+        <TextButton
+          variant={isActionEnabled ? "filled" : "disabled"}
+          size="wide"
+          onClick={onBanSelectedStudent}
         >
-          선택 해제
-        </button>
-      </div>
-      <TextButton
-        variant={
-          selectedBanTargetCount > 0 && !isPending ? "filled" : "disabled"
-        }
-        size="wide"
-        onClick={onBanSelectedStudent}
-      >
-        금지 시키기
-      </TextButton>
+          자습 금지
+        </TextButton>
+      ) : (
+        <TextButton
+          variant={isActionEnabled ? "outlined" : "disabled"}
+          size="wide"
+          onClick={onUnbanSelectedStudent}
+        >
+          자습 금지 해제
+        </TextButton>
+      )}
     </div>
   );
 }

--- a/src/features/self-study/ui/StudyBanActionPanel.tsx
+++ b/src/features/self-study/ui/StudyBanActionPanel.tsx
@@ -8,6 +8,7 @@ interface StudyBanActionPanelProps {
   selectedBanTargetCount: number;
   selectedUnbanTargetCount: number;
   isPending: boolean;
+  onClearSelection: () => void;
   onBanSelectedStudent: () => void;
   onUnbanSelectedStudent: () => void;
 }
@@ -17,6 +18,7 @@ export function StudyBanActionPanel({
   selectedBanTargetCount,
   selectedUnbanTargetCount,
   isPending,
+  onClearSelection,
   onBanSelectedStudent,
   onUnbanSelectedStudent,
 }: StudyBanActionPanelProps) {
@@ -37,7 +39,16 @@ export function StudyBanActionPanel({
 
   return (
     <div className="flex flex-col gap-[24px]">
-      <span className="text-main-text text-text-1">{actionTitle}</span>
+      <div className="flex items-end justify-between">
+        <span className="text-main-text text-text-1">{actionTitle}</span>
+        <button
+          type="button"
+          onClick={onClearSelection}
+          className="text-text-4 text-sub-1 hover:text-p-1 cursor-pointer transition-colors"
+        >
+          선택 해제
+        </button>
+      </div>
       {isAllowedFilterSelected ? (
         <TextButton
           variant={isActionEnabled ? "filled" : "disabled"}

--- a/src/shared/lib/useDebouncedValue.ts
+++ b/src/shared/lib/useDebouncedValue.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#57

## 📝작업 내용

### 자습 금지 해제 기능 추가
- `dormitoryMutations.unbanStudy` API 추가 (`entities` layer)
- `useUnbanStudy` 훅 구현으로 일괄 해제 처리 (`features` layer)
  - Promise.allSettled를 활용한 부분 성공/실패 처리
  - optimistic update를 통한 즉각적인 UI 반영
  - 상세한 토스트 메시지 제공 (성공/부분실패/실패)

### 학생 검색 디바운싱 추가
- `useDebouncedValue` 커스텀 훅 추가 (300ms 디바운스 적용)
- StudentManagementSection에서 검색 쿼리 디바운싱 처리
- 불필요한 필터링 연산 감소

### UI 개선
- StudyBanActionPanel 리팩토링
  - 필터 상태에 따른 동적 액션 버튼 (금지/해제)
  - 더 명확한 UX 플로우
- StudentManagementSection 스타일 정리
  - 빈 상태 스타일 간소화
- 필터 변경 시 선택 상태 초기화로 UX 개선