### PR TITLE
fix: 스크롤 스타일, 홈베이스 테이블 경계, transition UI 버그 수정

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -175,26 +175,26 @@ body {
 }
 
 /* 6. 스크롤바 스타일 */
-* {
+html {
   scrollbar-width: thin;
-  scrollbar-color: var(--color-sub-2) transparent;
+  scrollbar-color: var(--color-sub-2) var(--background);
 }
 
-*::-webkit-scrollbar {
+::-webkit-scrollbar {
   width: 6px;
   height: 6px;
 }
 
-*::-webkit-scrollbar-track {
-  background: transparent;
+::-webkit-scrollbar-track {
+  background: var(--background);
 }
 
-*::-webkit-scrollbar-thumb {
+::-webkit-scrollbar-thumb {
   background-color: var(--color-sub-2);
   border-radius: 9999px;
 }
 
-*::-webkit-scrollbar-button {
+::-webkit-scrollbar-button {
   display: none;
   width: 0;
   height: 0;

--- a/app/globals.css
+++ b/app/globals.css
@@ -172,9 +172,6 @@ body {
   background-color: var(--background);
   color: var(--color-main-text);
   font-family: "SUIT Variable", sans-serif;
-  transition:
-    background-color 0.3s ease,
-    color 0.3s ease;
 }
 
 /* 6. 스크롤바 스타일 */

--- a/src/entities/club/ui/ClubDetail.tsx
+++ b/src/entities/club/ui/ClubDetail.tsx
@@ -123,7 +123,7 @@ export default function ClubDetail({
             {isEdit ? (
               <div className="flex flex-col gap-1">
                 <textarea
-                  className="text-text-1 text-sub-1 border-sub-2 bg-background-surface focus:border-sub-1 w-full resize-none rounded-lg border p-4 transition-all outline-none"
+                  className="text-text-1 text-sub-1 border-sub-2 bg-background-surface focus:border-sub-1 w-full resize-none rounded-lg border p-4 outline-none"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                 />
@@ -169,7 +169,7 @@ export default function ClubDetail({
                               key={user.id}
                               type="button"
                               onClick={() => onMemberInvite?.(user)}
-                              className="text-text-2 text-main-text hover:bg-sub-4 w-full px-2 py-3 text-left transition-colors"
+                              className="text-text-2 text-main-text hover:bg-sub-4 w-full px-2 py-3 text-left"
                             >
                               {user.studentNumber} {user.name}
                             </button>
@@ -193,7 +193,7 @@ export default function ClubDetail({
                         <button
                           type="button"
                           onClick={() => onMemberExile(member.id)}
-                          className="text-sub-2 hover:text-negative flex shrink-0 items-center transition-colors [&>svg]:h-3 [&>svg]:w-3 2xl:[&>svg]:h-3.5 2xl:[&>svg]:w-3.5"
+                          className="text-sub-2 hover:text-negative flex shrink-0 items-center [&>svg]:h-3 [&>svg]:w-3 2xl:[&>svg]:h-3.5 2xl:[&>svg]:w-3.5"
                           aria-label={`${member.name} 추방`}
                         >
                           <Cancel />

--- a/src/features/ai-chat/ui/AiChatModal.tsx
+++ b/src/features/ai-chat/ui/AiChatModal.tsx
@@ -118,7 +118,7 @@ export function AiChatModal({ open, onClose }: AiChatModalProps) {
         <div className="border-sub-4 flex items-end justify-center gap-2 border-t px-4 py-3">
           <textarea
             ref={textareaRef}
-            className="border-sub-2 bg-background-surface text-main-text placeholder:text-sub-2 focus:border-sub-1 text-caption-1 caret-p-1 flex-1 resize-none rounded-[8px] border px-4 py-3 transition-colors outline-none"
+            className="border-sub-2 bg-background-surface text-main-text placeholder:text-sub-2 focus:border-sub-1 text-caption-1 caret-p-1 flex-1 resize-none rounded-[8px] border px-4 py-3 outline-none"
             rows={1}
             placeholder="메시지를 입력하세요"
             value={input}

--- a/src/features/club/ui/ClubApplicationField.tsx
+++ b/src/features/club/ui/ClubApplicationField.tsx
@@ -17,7 +17,7 @@ const fieldContainerStyles = "flex flex-col gap-2";
 const fieldLabelStyles = "text-text-3 text-main-text";
 const fieldDescriptionStyles = "text-caption-1 text-sub-1";
 const fieldBoxStyles =
-  "w-full rounded-lg border border-sub-2 bg-background-surface px-4 py-3 text-main-text outline-none transition-all placeholder:text-sub-2 focus:border-sub-1 caret-p-1";
+  "w-full rounded-lg border border-sub-2 bg-background-surface px-4 py-3 text-main-text outline-none placeholder:text-sub-2 focus:border-sub-1 caret-p-1";
 
 export function ClubApplicationField({
   field,
@@ -74,7 +74,7 @@ export function ClubApplicationField({
             return (
               <label
                 key={option.optionId}
-                className={`text-text-4 flex h-[43px] cursor-pointer items-center justify-center rounded-lg border px-4 transition-all ${optionStyles[state]}`}
+                className={`text-text-4 flex h-[43px] cursor-pointer items-center justify-center rounded-lg border px-4 ${optionStyles[state]}`}
               >
                 <input
                   type="radio"
@@ -100,7 +100,7 @@ export function ClubApplicationField({
             return (
               <label
                 key={option.optionId}
-                className={`text-text-4 flex h-[43px] cursor-pointer items-center justify-center rounded-lg border px-4 transition-all ${optionStyles[state]}`}
+                className={`text-text-4 flex h-[43px] cursor-pointer items-center justify-center rounded-lg border px-4 ${optionStyles[state]}`}
               >
                 <input
                   type="checkbox"

--- a/src/features/club/ui/ClubFormCreateSection.tsx
+++ b/src/features/club/ui/ClubFormCreateSection.tsx
@@ -19,10 +19,10 @@ interface ClubFormCreateSectionProps {
 }
 
 const fieldBoxStyles =
-  "w-full rounded-lg border border-sub-2 bg-background-surface px-4 py-3 text-main-text outline-none transition-all placeholder:text-sub-2 focus:border-sub-1 caret-p-1";
+  "w-full rounded-lg border border-sub-2 bg-background-surface px-4 py-3 text-main-text outline-none placeholder:text-sub-2 focus:border-sub-1 caret-p-1";
 
 const secondaryButtonStyles =
-  "h-[43px] rounded-lg border border-sub-2 bg-background-surface px-4 text-text-4 text-sub-1 transition-all hover:border-sub-1";
+  "h-[43px] rounded-lg border border-sub-2 bg-background-surface px-4 text-text-4 text-sub-1 hover:border-sub-1";
 
 function ClubFormCreateSectionLoading() {
   return (

--- a/src/features/club/ui/ClubFormEditSection.tsx
+++ b/src/features/club/ui/ClubFormEditSection.tsx
@@ -20,10 +20,10 @@ interface ClubFormEditSectionProps {
 }
 
 const fieldBoxStyles =
-  "w-full rounded-lg border border-sub-2 bg-background-surface px-4 py-3 text-main-text outline-none transition-all placeholder:text-sub-2 focus:border-sub-1 caret-p-1";
+  "w-full rounded-lg border border-sub-2 bg-background-surface px-4 py-3 text-main-text outline-none placeholder:text-sub-2 focus:border-sub-1 caret-p-1";
 
 const secondaryButtonStyles =
-  "h-[43px] rounded-lg border border-sub-2 bg-background-surface px-4 text-text-4 text-sub-1 transition-all hover:border-sub-1";
+  "h-[43px] rounded-lg border border-sub-2 bg-background-surface px-4 text-text-4 text-sub-1 hover:border-sub-1";
 
 interface ClubFormEditContentProps extends ClubFormEditSectionProps {
   form: ClubForm;

--- a/src/features/club/ui/ClubFormFieldEditor.tsx
+++ b/src/features/club/ui/ClubFormFieldEditor.tsx
@@ -31,10 +31,10 @@ interface ClubFormFieldEditorProps {
 }
 
 const fieldBoxStyles =
-  "w-full rounded-lg border border-sub-2 bg-background-surface px-4 py-3 text-main-text outline-none transition-all placeholder:text-sub-2 focus:border-sub-1 caret-p-1";
+  "w-full rounded-lg border border-sub-2 bg-background-surface px-4 py-3 text-main-text outline-none placeholder:text-sub-2 focus:border-sub-1 caret-p-1";
 
 const secondaryButtonStyles =
-  "h-[43px] rounded-lg border border-sub-2 bg-background-surface px-4 text-text-4 text-sub-1 transition-all hover:border-sub-1";
+  "h-[43px] rounded-lg border border-sub-2 bg-background-surface px-4 text-text-4 text-sub-1 hover:border-sub-1";
 
 export function ClubFormFieldEditor({
   field,

--- a/src/features/homebase/ui/SecondFloor.tsx
+++ b/src/features/homebase/ui/SecondFloor.tsx
@@ -37,12 +37,16 @@ export function SecondFloor({
         <Table
           name="테이블 3"
           capacity="4명"
-          className="border-sub-2 border-r"
+          className="border-sub-2"
           selected={selectedTable === "3"}
           reserved={!!reservedTables["3"]}
           members={reservedTables["3"] ?? []}
           onClick={() => onTableSelect("3")}
         />
+        <div className="border-sub-2 flex items-center justify-center border-x">
+          <span className="text-text-3 text-sub-2 font-medium">칸막이</span>
+        </div>
+        <div />
       </div>
     </FloorLayout>
   );

--- a/src/features/self-study/ui/ManagedStudentCard.tsx
+++ b/src/features/self-study/ui/ManagedStudentCard.tsx
@@ -34,7 +34,7 @@ export function ManagedStudentCard({
         aria-label={`${student.name} 선택`}
         aria-pressed={isSelected}
         onClick={() => onToggleSelect(student.id)}
-        className="hover:bg-background-surface absolute top-3 right-3 flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg transition-colors"
+        className="hover:bg-background-surface absolute top-3 right-3 flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg"
       >
         <Checkbox isActive={isSelected} />
       </button>

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -124,7 +124,7 @@ export function SelfStudySection() {
             <button
               type="button"
               onClick={handleResetFilters}
-              className="text-sub-1 text-caption-2 hover:text-p-1 cursor-pointer transition-colors"
+              className="text-sub-1 text-caption-2 hover:text-p-1 cursor-pointer"
             >
               초기화
             </button>

--- a/src/features/self-study/ui/StudentManagementFilterPanel.tsx
+++ b/src/features/self-study/ui/StudentManagementFilterPanel.tsx
@@ -50,7 +50,7 @@ export function StudentManagementFilterPanel({
           <button
             type="button"
             onClick={onResetFilters}
-            className="text-text-4 text-sub-1 hover:text-p-1 cursor-pointer transition-colors"
+            className="text-text-4 text-sub-1 hover:text-p-1 cursor-pointer"
           >
             초기화
           </button>

--- a/src/features/self-study/ui/StudyApplicantCard.tsx
+++ b/src/features/self-study/ui/StudyApplicantCard.tsx
@@ -36,7 +36,7 @@ export function StudyApplicantCard({
           aria-pressed={isChecked}
           disabled={isDisabled}
           onClick={() => onCheck(student.userId)}
-          className="enabled:hover:bg-background-surface absolute top-3 right-3 flex h-8 w-8 items-center justify-center rounded-lg transition-colors enabled:cursor-pointer disabled:cursor-default"
+          className="enabled:hover:bg-background-surface absolute top-3 right-3 flex h-8 w-8 items-center justify-center rounded-lg enabled:cursor-pointer disabled:cursor-default"
         >
           <Checkbox isActive={isChecked} />
         </button>

--- a/src/features/self-study/ui/StudyBanActionPanel.tsx
+++ b/src/features/self-study/ui/StudyBanActionPanel.tsx
@@ -22,7 +22,7 @@ export function StudyBanActionPanel({
         <button
           type="button"
           onClick={onClearSelection}
-          className="text-text-4 text-sub-1 hover:text-p-1 cursor-pointer transition-colors"
+          className="text-text-4 text-sub-1 hover:text-p-1 cursor-pointer"
         >
           선택 해제
         </button>

--- a/src/shared/ui/Calendar.tsx
+++ b/src/shared/ui/Calendar.tsx
@@ -112,7 +112,7 @@ export function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
                 if (!isCurrentMonth) setViewDate(date);
                 onDateSelect?.(date);
               }}
-              className={`text-caption-1 flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg p-2 transition-colors outline-none ${
+              className={`text-caption-1 flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg p-2 outline-none ${
                 isSelected
                   ? "bg-p-1 text-sub-4"
                   : isCurrentMonth

--- a/src/shared/ui/ImageUpload.tsx
+++ b/src/shared/ui/ImageUpload.tsx
@@ -83,7 +83,7 @@ export default function ImageUpload({
             {!disabled && (
               <button
                 onClick={handleDelete}
-                className="absolute top-2 right-2 cursor-pointer p-1 transition-all"
+                className="absolute top-2 right-2 cursor-pointer p-1"
               >
                 <Delete className="text-negative" />
               </button>

--- a/src/shared/ui/Toggle/DarkModeToggle.tsx
+++ b/src/shared/ui/Toggle/DarkModeToggle.tsx
@@ -27,7 +27,7 @@ export function DarkModeToggle() {
   return (
     <button
       onClick={toggle}
-      className={`relative flex h-[39px] w-[70px] cursor-pointer items-center rounded-[43px] p-1 transition-colors duration-300 ${
+      className={`relative flex h-[39px] w-[70px] cursor-pointer items-center rounded-[43px] p-1 ${
         isDark ? "bg-background-surface" : "bg-sub-3"
       }`}
     >

--- a/src/shared/ui/textField.tsx
+++ b/src/shared/ui/textField.tsx
@@ -14,7 +14,7 @@ export default function TextField({
   return (
     <div className={`relative ${className}`}>
       <input
-        className={`bg-background-surface border-sub-2 text-main-text placeholder:text-sub-2 focus:border-sub-1 h-[52px] w-full rounded-[8px] border pl-4 caret-[#527CD7] transition-all outline-none ${rightIcon ? "pr-12" : "pr-4"} ${inputClassName ?? ""} `}
+        className={`bg-background-surface border-sub-2 text-main-text placeholder:text-sub-2 focus:border-sub-1 h-[52px] w-full rounded-[8px] border pl-4 caret-[#527CD7] outline-none ${rightIcon ? "pr-12" : "pr-4"} ${inputClassName ?? ""} `}
         {...props}
       />
 

--- a/src/widgets/adaptive-sidebar/ui/index.tsx
+++ b/src/widgets/adaptive-sidebar/ui/index.tsx
@@ -73,7 +73,7 @@ export default function Sidebar() {
 
       <button
         type="button"
-        className="flex h-14 w-full cursor-pointer items-center justify-center py-3 transition-all lg:justify-start lg:px-4"
+        className="flex h-14 w-full cursor-pointer items-center justify-center py-3 lg:justify-start lg:px-4"
         onClick={handleLogout}
       >
         <div className="flex items-center gap-6">

--- a/src/widgets/adaptive-sidebar/ui/sidebarMenu.tsx
+++ b/src/widgets/adaptive-sidebar/ui/sidebarMenu.tsx
@@ -13,7 +13,7 @@ export function SidebarMenu({ title, isActive, href, icon }: SidebarMenuProps) {
   return (
     <Link href={href}>
       <div
-        className={`group flex h-14 w-full cursor-pointer items-center justify-center rounded-2xl py-3 transition-all lg:justify-start lg:px-4 ${isActive ? "bg-p-2" : "hover:bg-p-2 bg-transparent"} `}
+        className={`group flex h-14 w-full cursor-pointer items-center justify-center rounded-2xl py-3 lg:justify-start lg:px-4 ${isActive ? "bg-p-2" : "hover:bg-p-2 bg-transparent"} `}
       >
         <div className="flex items-center justify-center lg:grid lg:w-full lg:grid-cols-[32px_minmax(0,1fr)] lg:gap-6">
           <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
@@ -27,7 +27,7 @@ export function SidebarMenu({ title, isActive, href, icon }: SidebarMenuProps) {
             )}
           </div>
           <span
-            className={`text-text-1 hidden transition-all lg:block ${isActive ? "text-p-1" : "text-sub-2 group-hover:text-p-1"} `}
+            className={`text-text-1 hidden lg:block ${isActive ? "text-p-1" : "text-sub-2 group-hover:text-p-1"} `}
           >
             {title}
           </span>

--- a/src/widgets/main/ui/ApplyCard.tsx
+++ b/src/widgets/main/ui/ApplyCard.tsx
@@ -51,7 +51,7 @@ export default function ApplyCard({
         {detailHref && (
           <Link
             href={detailHref}
-            className="text-text-3 text-sub-2 hover:text-p-1 flex items-center transition-colors"
+            className="text-text-3 text-sub-2 hover:text-p-1 flex items-center"
           >
             전체보기
             <ChevronRight direction="right" />

--- a/src/widgets/main/ui/HomebaseCard.tsx
+++ b/src/widgets/main/ui/HomebaseCard.tsx
@@ -159,7 +159,7 @@ export default function HomebaseCard({
                 value={reason}
                 maxLength={20}
                 onChange={(event) => handleReasonChange(event.target.value)}
-                className="border-sub-2 bg-background-surface text-main-text caret-p-1 placeholder:text-sub-2 focus:border-sub-1 h-30 w-full resize-none rounded-lg border p-4 transition-all outline-none"
+                className="border-sub-2 bg-background-surface text-main-text caret-p-1 placeholder:text-sub-2 focus:border-sub-1 h-30 w-full resize-none rounded-lg border p-4 outline-none"
               />
               <span className="text-size-caption-1 text-sub-2 text-right">
                 {reason.length}/20


### PR DESCRIPTION
## #️⃣연관된 이슈

#96

## 📝작업 내용

### 스크롤바 스타일 개선 (Firefox/Safari 호환성)
- `*` 셀렉터 대신 `html` 및 `::-webkit-scrollbar` 계열 셀렉터로 변경하여 브라우저 호환성 확보
- 스크롤바 트랙 배경을 `transparent`에서 `var(--background)`로 수정해 색상 토큰 일관성 유지

### 테마 변경 지연 문제 해결 (`transition` 제거)
- `body`의 `background-color`, `color` transition 제거
- `entities/club`, `features/ai-chat`, `features/club`, `features/self-study`, `shared/ui`, `widgets` 레이어 전반의 컴포넌트에서 `transition-colors` / `transition-all` 클래스 제거 (21개 파일)

### 2층 홈베이스 테이블 경계 불일치 수정
- `SecondFloor.tsx`에서 테이블 3의 우측 border 제거 후 별도 칸막이 구분 요소 추가
- 그리드 빈 셀 추가로 레이아웃 정렬 일관성 확보

### 크로미움
<img width="2558" height="1418" alt="image" src="https://github.com/user-attachments/assets/bb3359eb-0271-480d-8410-3320114539ff" />

### 파이어폭스
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/07954d2a-b46e-42a7-a35d-f8f91116dbe5" />

### 사파리
<img width="3420" height="2042" alt="image" src="https://github.com/user-attachments/assets/4bd1d982-6574-487a-8feb-ddf127b86a66" />

