### PR TITLE
change: 신청 상태 관리 및 토스트 알림 추가

### DIFF
--- a/src/entities/dormitory/api/getDormitory.ts
+++ b/src/entities/dormitory/api/getDormitory.ts
@@ -1,8 +1,8 @@
 import { instance } from "@/shared/api/instance";
 import type {
-  DormitoryStudent,
   DormitoryMusic,
-  StudyApplicant,
+  MassageApplicants,
+  StudyApplicants,
   MyPenaltyResponse,
   AllPenaltiesResponse,
   CleaningZones,
@@ -34,22 +34,24 @@ export async function getDormitoryMusic(
   }));
 }
 
-type DormitoryStudentResponse =
-  | DormitoryStudent[]
-  | { data?: DormitoryStudent[] };
-type StudyApplicantResponse = StudyApplicant[] | { data?: StudyApplicant[] };
+type ApiResponse<TData> = {
+  status: string;
+  code: number;
+  message: string;
+  data: TData;
+};
 
-export async function getMassageApplicants(): Promise<DormitoryStudent[]> {
-  const { data } = await instance.get<DormitoryStudentResponse>(
+export async function getMassageApplicants(): Promise<MassageApplicants> {
+  const { data } = await instance.get<ApiResponse<MassageApplicants>>(
     "/dormitory/massages",
   );
-  return Array.isArray(data) ? data : (data.data ?? []);
+  return data.data;
 }
 
-export async function getSelfStudyApplicants(): Promise<StudyApplicant[]> {
+export async function getSelfStudyApplicants(): Promise<StudyApplicants> {
   const { data } =
-    await instance.get<StudyApplicantResponse>("/dormitory/studies");
-  return Array.isArray(data) ? data : (data.data ?? []);
+    await instance.get<ApiResponse<StudyApplicants>>("/dormitory/studies");
+  return data.data;
 }
 
 export async function getMyPenalties(): Promise<MyPenaltyResponse> {

--- a/src/entities/dormitory/model/dormitory.ts
+++ b/src/entities/dormitory/model/dormitory.ts
@@ -19,6 +19,14 @@ export interface StudyApplicant {
   isChecked: boolean;
 }
 
+export interface ApplicationStatus<TApplicant> {
+  isApplicationOpen: boolean;
+  applicants: TApplicant[];
+}
+
+export type MassageApplicants = ApplicationStatus<DormitoryStudent>;
+export type StudyApplicants = ApplicationStatus<StudyApplicant>;
+
 export interface MusicApplyRequest {
   musicUrl: string;
 }

--- a/src/features/massage-chair/model/useApplyMassage.ts
+++ b/src/features/massage-chair/model/useApplyMassage.ts
@@ -14,8 +14,10 @@ export function useApplyMassage() {
 
   return useMutation({
     mutationFn: dormitoryMutations.applyMassage,
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: massageQuery.queryKey }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: massageQuery.queryKey });
+      toast.success("안마의자 신청이 완료되었습니다.");
+    },
     onError: (error) => {
       const status = axios.isAxiosError(error)
         ? error.response?.status

--- a/src/features/massage-chair/model/useCancelMassage.ts
+++ b/src/features/massage-chair/model/useCancelMassage.ts
@@ -14,8 +14,10 @@ export function useCancelMassage() {
 
   return useMutation({
     mutationFn: dormitoryMutations.cancelMassage,
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: massageQuery.queryKey }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: massageQuery.queryKey });
+      toast.success("안마의자 신청이 취소되었습니다.");
+    },
     onError: (error) => {
       const status = axios.isAxiosError(error)
         ? error.response?.status

--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -11,7 +11,8 @@ import { useCancelMassage } from "../model/useCancelMassage";
 
 export function MassageChairSection() {
   const massageQuery = dormitoryQueries.massage();
-  const { data: massageApplicants } = useQuery(massageQuery);
+  const { data: massageApplicants, isLoading: isMassageLoading } =
+    useQuery(massageQuery);
   const applicants = massageApplicants?.applicants ?? [];
   const isApplicationOpen = massageApplicants?.isApplicationOpen ?? false;
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
@@ -23,7 +24,10 @@ export function MassageChairSection() {
   const isMassageActionPending =
     applyMutation.isPending || cancelMutation.isPending;
   const isMassageActionDisabled =
-    isUserLoading || isMassageActionPending || !isApplicationOpen;
+    isUserLoading ||
+    isMassageLoading ||
+    isMassageActionPending ||
+    !isApplicationOpen;
 
   const handleApplyMassage = () => {
     if (isMassageActionDisabled || hasAppliedMassage) {
@@ -76,7 +80,7 @@ export function MassageChairSection() {
               hasAppliedMassage ? handleCancelMassage : handleApplyMassage
             }
           >
-            {isUserLoading
+            {isUserLoading || isMassageLoading
               ? "확인 중"
               : !isApplicationOpen
                 ? "신청 불가"

--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -11,7 +11,9 @@ import { useCancelMassage } from "../model/useCancelMassage";
 
 export function MassageChairSection() {
   const massageQuery = dormitoryQueries.massage();
-  const { data: applicants = [] } = useQuery(massageQuery);
+  const { data: massageApplicants } = useQuery(massageQuery);
+  const applicants = massageApplicants?.applicants ?? [];
+  const isApplicationOpen = massageApplicants?.isApplicationOpen ?? false;
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const applyMutation = useApplyMassage();
   const cancelMutation = useCancelMassage();
@@ -20,7 +22,8 @@ export function MassageChairSection() {
     applicants.some((student) => student.studentNumber === user.studentNumber);
   const isMassageActionPending =
     applyMutation.isPending || cancelMutation.isPending;
-  const isMassageActionDisabled = isUserLoading || isMassageActionPending;
+  const isMassageActionDisabled =
+    isUserLoading || isMassageActionPending || !isApplicationOpen;
 
   const handleApplyMassage = () => {
     if (isMassageActionDisabled || hasAppliedMassage) {
@@ -75,9 +78,11 @@ export function MassageChairSection() {
           >
             {isUserLoading
               ? "확인 중"
-              : hasAppliedMassage
-                ? "취소하기"
-                : "신청하기"}
+              : !isApplicationOpen
+                ? "신청 불가"
+                : hasAppliedMassage
+                  ? "취소하기"
+                  : "신청하기"}
           </TextButton>
           <p className="text-sub-2 text-caption-2">
             안마의자 신청시간은 20:20 ~ 21:00 입니다

--- a/src/features/self-study/model/useApplyStudy.ts
+++ b/src/features/self-study/model/useApplyStudy.ts
@@ -14,8 +14,10 @@ export function useApplyStudy() {
 
   return useMutation({
     mutationFn: dormitoryMutations.applyStudy,
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey });
+      toast.success("자습 신청이 완료되었습니다.");
+    },
     onError: (error) => {
       const status = axios.isAxiosError(error)
         ? error.response?.status

--- a/src/features/self-study/model/useCancelStudy.ts
+++ b/src/features/self-study/model/useCancelStudy.ts
@@ -14,8 +14,10 @@ export function useCancelStudy() {
 
   return useMutation({
     mutationFn: dormitoryMutations.cancelStudy,
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: studyQuery.queryKey });
+      toast.success("자습 신청이 취소되었습니다.");
+    },
     onError: (error) => {
       const status = axios.isAxiosError(error)
         ? error.response?.status

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -21,7 +21,9 @@ const CLASS_OPTIONS = [1, 2, 3, 4] as const;
 
 export function SelfStudySection() {
   const studyQuery = dormitoryQueries.study();
-  const { data: students = [] } = useQuery(studyQuery);
+  const { data: studyApplicants } = useQuery(studyQuery);
+  const students = studyApplicants?.applicants ?? [];
+  const isApplicationOpen = studyApplicants?.isApplicationOpen ?? false;
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const { state, filteredStudents, dispatch } = useStudyFilter(students);
   const { searchQuery, selectedGrades, selectedClasses, selectedGender } =
@@ -35,7 +37,10 @@ export function SelfStudySection() {
   const isStudyActionPending =
     applyMutation.isPending || cancelMutation.isPending;
   const isStudyActionDisabled =
-    isUserLoading || isStudyBanned || isStudyActionPending;
+    isUserLoading ||
+    isStudyBanned ||
+    isStudyActionPending ||
+    !isApplicationOpen;
   const canManageStudy = isManagementRole(user?.role);
   const { checkedStudentIds, markChecked } = useStudyAttendanceSubscription(
     user?.role,
@@ -211,9 +216,11 @@ export function SelfStudySection() {
               ? "자습 금지를 당했어요!"
               : isUserLoading
                 ? "확인 중"
-                : hasAppliedStudy
-                  ? "취소하기"
-                  : "신청하기"}
+                : !isApplicationOpen
+                  ? "신청 불가"
+                  : hasAppliedStudy
+                    ? "취소하기"
+                    : "신청하기"}
           </TextButton>
 
           <p className="text-sub-2 text-caption-2">

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -21,7 +21,8 @@ const CLASS_OPTIONS = [1, 2, 3, 4] as const;
 
 export function SelfStudySection() {
   const studyQuery = dormitoryQueries.study();
-  const { data: studyApplicants } = useQuery(studyQuery);
+  const { data: studyApplicants, isLoading: isStudyLoading } =
+    useQuery(studyQuery);
   const students = studyApplicants?.applicants ?? [];
   const isApplicationOpen = studyApplicants?.isApplicationOpen ?? false;
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
@@ -38,6 +39,7 @@ export function SelfStudySection() {
     applyMutation.isPending || cancelMutation.isPending;
   const isStudyActionDisabled =
     isUserLoading ||
+    isStudyLoading ||
     isStudyBanned ||
     isStudyActionPending ||
     !isApplicationOpen;
@@ -214,7 +216,7 @@ export function SelfStudySection() {
           >
             {isStudyBanned
               ? "자습 금지를 당했어요!"
-              : isUserLoading
+              : isUserLoading || isStudyLoading
                 ? "확인 중"
                 : !isApplicationOpen
                   ? "신청 불가"

--- a/src/widgets/main/ui/MassageApplyCard.tsx
+++ b/src/widgets/main/ui/MassageApplyCard.tsx
@@ -12,7 +12,8 @@ const MASSAGE_MAX = 5;
 
 export default function MassageApplyCard() {
   const massageQuery = dormitoryQueries.massage();
-  const { data: massageApplicants } = useQuery(massageQuery);
+  const { data: massageApplicants, isLoading: isMassageLoading } =
+    useQuery(massageQuery);
   const applicants = massageApplicants?.applicants ?? [];
   const isApplicationOpen = massageApplicants?.isApplicationOpen ?? false;
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
@@ -24,7 +25,10 @@ export default function MassageApplyCard() {
   const isMassageActionPending =
     applyMutation.isPending || cancelMutation.isPending;
   const isMassageActionDisabled =
-    isUserLoading || isMassageActionPending || !isApplicationOpen;
+    isUserLoading ||
+    isMassageLoading ||
+    isMassageActionPending ||
+    !isApplicationOpen;
 
   const handleApplyMassage = () => {
     if (isMassageActionDisabled || hasAppliedMassage) {
@@ -50,7 +54,7 @@ export default function MassageApplyCard() {
       total={MASSAGE_MAX}
       timeText="안마 의자 신청 시간은 20:20 ~ 21:00에 신청이 가능해요"
       buttonText={
-        isUserLoading
+        isUserLoading || isMassageLoading
           ? "확인 중"
           : !isApplicationOpen
             ? "신청 불가"

--- a/src/widgets/main/ui/MassageApplyCard.tsx
+++ b/src/widgets/main/ui/MassageApplyCard.tsx
@@ -12,7 +12,9 @@ const MASSAGE_MAX = 5;
 
 export default function MassageApplyCard() {
   const massageQuery = dormitoryQueries.massage();
-  const { data: applicants = [] } = useQuery(massageQuery);
+  const { data: massageApplicants } = useQuery(massageQuery);
+  const applicants = massageApplicants?.applicants ?? [];
+  const isApplicationOpen = massageApplicants?.isApplicationOpen ?? false;
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const applyMutation = useApplyMassage();
   const cancelMutation = useCancelMassage();
@@ -21,7 +23,8 @@ export default function MassageApplyCard() {
     applicants.some((student) => student.studentNumber === user.studentNumber);
   const isMassageActionPending =
     applyMutation.isPending || cancelMutation.isPending;
-  const isMassageActionDisabled = isUserLoading || isMassageActionPending;
+  const isMassageActionDisabled =
+    isUserLoading || isMassageActionPending || !isApplicationOpen;
 
   const handleApplyMassage = () => {
     if (isMassageActionDisabled || hasAppliedMassage) {
@@ -47,8 +50,15 @@ export default function MassageApplyCard() {
       total={MASSAGE_MAX}
       timeText="안마 의자 신청 시간은 20:20 ~ 21:00에 신청이 가능해요"
       buttonText={
-        isUserLoading ? "확인 중" : hasAppliedMassage ? "취소" : "신청"
+        isUserLoading
+          ? "확인 중"
+          : !isApplicationOpen
+            ? "신청 불가"
+            : hasAppliedMassage
+              ? "취소"
+              : "신청"
       }
+      buttonSize={!isApplicationOpen ? "fit" : "small"}
       detailHref="/dormitory"
       femaleNotice
       disabled={isMassageActionDisabled}

--- a/src/widgets/main/ui/StudyApplyCard.tsx
+++ b/src/widgets/main/ui/StudyApplyCard.tsx
@@ -12,7 +12,9 @@ const STUDY_MAX = 50;
 
 export default function StudyApplyCard() {
   const studyQuery = dormitoryQueries.study();
-  const { data: students = [] } = useQuery(studyQuery);
+  const { data: studyApplicants } = useQuery(studyQuery);
+  const students = studyApplicants?.applicants ?? [];
+  const isApplicationOpen = studyApplicants?.isApplicationOpen ?? false;
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
   const applyMutation = useApplyStudy();
   const cancelMutation = useCancelStudy();
@@ -23,7 +25,10 @@ export default function StudyApplyCard() {
   const isStudyActionPending =
     applyMutation.isPending || cancelMutation.isPending;
   const isStudyActionDisabled =
-    isUserLoading || isStudyBanned || isStudyActionPending;
+    isUserLoading ||
+    isStudyBanned ||
+    isStudyActionPending ||
+    !isApplicationOpen;
 
   const handleApplyStudy = () => {
     if (isStudyActionDisabled || hasAppliedStudy) {
@@ -53,12 +58,14 @@ export default function StudyApplyCard() {
           ? "자습 금지를 당했어요!"
           : isUserLoading
             ? "확인 중"
-            : hasAppliedStudy
-              ? "취소"
-              : "신청"
+            : !isApplicationOpen
+              ? "신청 불가"
+              : hasAppliedStudy
+                ? "취소"
+                : "신청"
       }
       buttonVariant={isStudyBanned ? "negative" : "filled"}
-      buttonSize={isStudyBanned ? "fit" : "small"}
+      buttonSize={isStudyBanned || !isApplicationOpen ? "fit" : "small"}
       detailHref="/dormitory"
       disabled={isStudyActionDisabled}
       onApply={hasAppliedStudy ? handleCancelStudy : handleApplyStudy}

--- a/src/widgets/main/ui/StudyApplyCard.tsx
+++ b/src/widgets/main/ui/StudyApplyCard.tsx
@@ -12,7 +12,8 @@ const STUDY_MAX = 50;
 
 export default function StudyApplyCard() {
   const studyQuery = dormitoryQueries.study();
-  const { data: studyApplicants } = useQuery(studyQuery);
+  const { data: studyApplicants, isLoading: isStudyLoading } =
+    useQuery(studyQuery);
   const students = studyApplicants?.applicants ?? [];
   const isApplicationOpen = studyApplicants?.isApplicationOpen ?? false;
   const { data: user, isLoading: isUserLoading } = useQuery(userQueries.me());
@@ -26,6 +27,7 @@ export default function StudyApplyCard() {
     applyMutation.isPending || cancelMutation.isPending;
   const isStudyActionDisabled =
     isUserLoading ||
+    isStudyLoading ||
     isStudyBanned ||
     isStudyActionPending ||
     !isApplicationOpen;
@@ -56,7 +58,7 @@ export default function StudyApplyCard() {
       buttonText={
         isStudyBanned
           ? "자습 금지를 당했어요!"
-          : isUserLoading
+          : isUserLoading || isStudyLoading
             ? "확인 중"
             : !isApplicationOpen
               ? "신청 불가"


### PR DESCRIPTION
## #️⃣연관된 이슈

#95

## 📝작업 내용

### API 응답 정규화
- 마사지/자습 API 응답을 표준화된 `ApiResponse<T>` 타입으로 변경
- `ApplicationStatus<T>` 제네릭 타입 추가: `{ isApplicationOpen: boolean, applicants: T[] }`
- `MassageApplicants`, `StudyApplicants` 타입 정의

### 신청/취소 성공 시 토스트 알림
- 마사지 신청/취소: "안마의자 신청이 완료/취소되었습니다."
- 자습 신청/취소: "자습 신청이 완료/취소되었습니다."

### 신청 상태 관리 UI
- `isApplicationOpen` 상태에 따른 버튼 상태 업데이트
  - 신청 불가 시 버튼 텍스트 "신청 불가" 표시
  - 버튼 비활성화 처리
  - 버튼 크기 조정 (fit → small)
- 영향 범위: MassageChairSection, SelfStudySection, MassageApplyCard, StudyApplyCard