### PR TITLE
refactor: 동아리 신청 구조 개선 및 UI 통합

### DIFF
--- a/src/entities/club/api/getClubOpeningStatus.ts
+++ b/src/entities/club/api/getClubOpeningStatus.ts
@@ -1,6 +1,7 @@
 import { instance } from "@/shared/api/instance";
+import type { ClubOpeningStatus } from "../model/club";
 
-export async function getClubOpeningStatus(): Promise<boolean> {
+export async function getClubOpeningStatus(): Promise<ClubOpeningStatus> {
   const { data: body } = await instance.get("/clubs/opening-status");
-  return Boolean(body.data?.isOpened);
+  return body.data;
 }

--- a/src/entities/club/api/postClub.ts
+++ b/src/entities/club/api/postClub.ts
@@ -6,8 +6,8 @@ export const postClub = async (body: {
   description: string;
   type: ClubType;
   status: ClubStatus;
-  imageUrl?: string;
-  maxMember?: number;
+  imageUrl: string;
+  maxMember: number;
 }) => {
   const { data } = await instance.post("/clubs", body);
   return data;

--- a/src/entities/club/model/club.ts
+++ b/src/entities/club/model/club.ts
@@ -164,12 +164,10 @@ export interface ClubOpeningStatus {
 }
 
 export interface RegistrationData {
-  regType: RegistrationType;
-  clubType: ClubType;
+  name: string;
   status: ClubStatus;
-  clubName: string;
-  leaderInfo: string;
-  clubDetail: string;
-  desiredTeacher: string;
-  clubImage: File | string | null;
+  type: ClubType;
+  description: string;
+  imageUrl: string;
+  maxMember: number;
 }

--- a/src/entities/club/model/club.ts
+++ b/src/entities/club/model/club.ts
@@ -157,6 +157,12 @@ export interface ClubApplicationListResponse {
   applications: ClubApplicationSummary[];
 }
 
+export interface ClubOpeningStatus {
+  isOpened: boolean;
+  startDate: string | null;
+  endDate: string | null;
+}
+
 export interface RegistrationData {
   regType: RegistrationType;
   clubType: ClubType;

--- a/src/entities/club/ui/ClubActionButtons.tsx
+++ b/src/entities/club/ui/ClubActionButtons.tsx
@@ -21,7 +21,7 @@ export function ClubActionButtons({
   if (isEdit) {
     return (
       <>
-        <div className={`flex gap-2 ${canDelete ? "w-[350px]" : "w-[240px]"}`}>
+        <div className="flex gap-2">
           <TextButton
             size="fit"
             variant="ghost"

--- a/src/entities/club/ui/ClubDetail.tsx
+++ b/src/entities/club/ui/ClubDetail.tsx
@@ -9,6 +9,7 @@ import { ClubActionButtons } from "@/entities/club/ui/ClubActionButtons";
 import Edit from "@/shared/asset/svg/Edit";
 import Search from "@/shared/asset/svg/Search";
 import Cancel from "@/shared/asset/svg/Cancel";
+import Smile from "@/shared/asset/svg/Smile";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import TextField from "@/shared/ui/textField";
 import ClubMemberList from "./ClubMemberList";
@@ -21,6 +22,7 @@ import FileOff from "@/shared/asset/svg/FileOff";
 interface ClubDetailProps {
   detail: ClubDetailResponse;
   isApplyPending?: boolean;
+  applyDisabledMessage?: string;
   onApplyClick?: () => void;
   onViewApplicationsClick?: () => void;
   onCreateFormClick?: () => void;
@@ -38,6 +40,7 @@ interface ClubDetailProps {
 export default function ClubDetail({
   detail,
   isApplyPending = false,
+  applyDisabledMessage,
   onApplyClick,
   onViewApplicationsClick,
   onCreateFormClick,
@@ -59,7 +62,12 @@ export default function ClubDetail({
   const [description, setDescription] = useState(club.description ?? "");
   const [previewUrl, setPreviewUrl] = useState(club.imageUrl ?? "");
 
-  const applyVariant = isApplyPending || !onApplyClick ? "disabled" : "filled";
+  const applyVariant =
+    isApplyPending || !onApplyClick || applyDisabledMessage
+      ? "disabled"
+      : "filled";
+  const shouldShowApplyButton =
+    !isLeader && (!!onApplyClick || !!applyDisabledMessage);
   const nonLeaderMembers = members.filter((m) =>
     club.leaderId !== undefined
       ? m.id !== club.leaderId
@@ -270,15 +278,27 @@ export default function ClubDetail({
                   {formActionLabel}
                 </TextButton>
               )}
-              {!isLeader && onApplyClick && (
-                <TextButton
-                  size="fit"
-                  variant={applyVariant}
-                  className="flex-1"
-                  onClick={applyVariant === "filled" ? onApplyClick : undefined}
-                >
-                  동아리 신청하기
-                </TextButton>
+              {shouldShowApplyButton && (
+                <div className="flex flex-col items-end gap-2">
+                  {applyDisabledMessage && (
+                    <div className="flex items-center gap-2">
+                      <Smile />
+                      <p className="text-sub-2 text-text-1">
+                        {applyDisabledMessage}
+                      </p>
+                    </div>
+                  )}
+                  <TextButton
+                    size="fit"
+                    variant={applyVariant}
+                    className="flex-1"
+                    onClick={
+                      applyVariant === "filled" ? onApplyClick : undefined
+                    }
+                  >
+                    동아리 신청하기
+                  </TextButton>
+                </div>
               )}
             </>
           )}

--- a/src/entities/club/ui/ClubDetail.tsx
+++ b/src/entities/club/ui/ClubDetail.tsx
@@ -9,7 +9,6 @@ import { ClubActionButtons } from "@/entities/club/ui/ClubActionButtons";
 import Edit from "@/shared/asset/svg/Edit";
 import Search from "@/shared/asset/svg/Search";
 import Cancel from "@/shared/asset/svg/Cancel";
-import Smile from "@/shared/asset/svg/Smile";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import TextField from "@/shared/ui/textField";
 import ClubMemberList from "./ClubMemberList";
@@ -241,7 +240,7 @@ export default function ClubDetail({
                 setIsEdit(true);
                 onEditClick?.();
               }}
-              className="bg-sub-4 flex items-center justify-center rounded-xl p-2.5"
+              className="bg-sub-4 flex cursor-pointer items-center justify-center rounded-xl p-2.5"
               aria-label="동아리 수정"
             >
               <Edit />
@@ -279,26 +278,13 @@ export default function ClubDetail({
                 </TextButton>
               )}
               {shouldShowApplyButton && (
-                <div className="flex flex-col items-end gap-2">
-                  {applyDisabledMessage && (
-                    <div className="flex items-center gap-2">
-                      <Smile />
-                      <p className="text-sub-2 text-text-1">
-                        {applyDisabledMessage}
-                      </p>
-                    </div>
-                  )}
-                  <TextButton
-                    size="fit"
-                    variant={applyVariant}
-                    className="flex-1"
-                    onClick={
-                      applyVariant === "filled" ? onApplyClick : undefined
-                    }
-                  >
-                    동아리 신청하기
-                  </TextButton>
-                </div>
+                <TextButton
+                  size="wide"
+                  variant={applyVariant}
+                  onClick={applyVariant === "filled" ? onApplyClick : undefined}
+                >
+                  {applyDisabledMessage ? "신청 불가" : "동아리 신청하기"}
+                </TextButton>
               )}
             </>
           )}

--- a/src/features/club/lib/filterClubs.ts
+++ b/src/features/club/lib/filterClubs.ts
@@ -1,19 +1,19 @@
-import type { Club } from "@/entities/club/model/club";
+import type { Club, ClubOpeningStatus } from "@/entities/club/model/club";
 
 interface FilterClubsParams {
   clubs: Club[];
-  isRegistrationPeriod: boolean;
+  openingStatus: ClubOpeningStatus;
   searchValue: string;
 }
 
 export function filterClubs({
   clubs,
-  isRegistrationPeriod,
+  openingStatus,
   searchValue,
 }: FilterClubsParams): Club[] {
   const normalizedSearchValue = searchValue.trim().toLowerCase();
 
-  if (!normalizedSearchValue || isRegistrationPeriod) {
+  if (!normalizedSearchValue || openingStatus.isOpened) {
     return clubs;
   }
 

--- a/src/features/club/lib/filterClubs.ts
+++ b/src/features/club/lib/filterClubs.ts
@@ -5,10 +5,7 @@ interface FilterClubsParams {
   searchValue: string;
 }
 
-export function filterClubs({
-  clubs,
-  searchValue,
-}: FilterClubsParams): Club[] {
+export function filterClubs({ clubs, searchValue }: FilterClubsParams): Club[] {
   const normalizedSearchValue = searchValue.trim().toLowerCase();
 
   if (!normalizedSearchValue) {

--- a/src/features/club/lib/filterClubs.ts
+++ b/src/features/club/lib/filterClubs.ts
@@ -1,19 +1,17 @@
-import type { Club, ClubOpeningStatus } from "@/entities/club/model/club";
+import type { Club } from "@/entities/club/model/club";
 
 interface FilterClubsParams {
   clubs: Club[];
-  openingStatus: ClubOpeningStatus;
   searchValue: string;
 }
 
 export function filterClubs({
   clubs,
-  openingStatus,
   searchValue,
 }: FilterClubsParams): Club[] {
   const normalizedSearchValue = searchValue.trim().toLowerCase();
 
-  if (!normalizedSearchValue || openingStatus.isOpened) {
+  if (!normalizedSearchValue) {
     return clubs;
   }
 

--- a/src/features/club/ui/ClubApplicationListSection.tsx
+++ b/src/features/club/ui/ClubApplicationListSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import axios, { HttpStatusCode } from "axios";
 import Club from "@/shared/asset/svg/Club";
@@ -82,6 +83,8 @@ function ClubApplicationListSectionError({
   error,
   resetErrorBoundary,
 }: QueryErrorFallbackProps) {
+  const router = useRouter();
+
   return (
     <div className="flex min-h-0 w-full flex-1 overflow-y-auto sm:px-8 lg:px-8 xl:px-10 xl:pb-6 2xl:px-18">
       <div className="bg-background-surface flex h-[520px] min-h-0 w-full flex-col items-center justify-center gap-3 rounded-2xl p-6">
@@ -89,9 +92,22 @@ function ClubApplicationListSectionError({
         <p className="text-text-1 text-main-text text-center">
           {getErrorMessage(error)}
         </p>
-        <TextButton variant="outlined" size="fit" onClick={resetErrorBoundary}>
-          다시 시도
-        </TextButton>
+        <div className="flex gap-3">
+          <TextButton
+            variant="outlined"
+            size="fit"
+            onClick={resetErrorBoundary}
+          >
+            다시 시도
+          </TextButton>
+          <TextButton
+            variant="outlined"
+            size="fit"
+            onClick={() => router.back()}
+          >
+            뒤로가기
+          </TextButton>
+        </div>
       </div>
     </div>
   );

--- a/src/features/club/ui/ClubDetailSection.tsx
+++ b/src/features/club/ui/ClubDetailSection.tsx
@@ -107,14 +107,13 @@ const ClubDetailSection = ({
 
   const { data: detail } = useSuspenseQuery(clubQueries.detail(id));
   const { data: user } = useSuspenseQuery(userQueries.me());
-  const { data: isRegistrationPeriod = false } = useSuspenseQuery(
-    clubQueries.openingStatus(),
-  );
+  const { data: openingStatus } = useSuspenseQuery(clubQueries.openingStatus());
 
   const isLeader = detail.isLeader;
   const isManager = user.role === "ADMIN" || user.role === "STUDENT_COUNCIL";
+  const hasClubApplication = user.hasClubApplication ?? false;
   const canDeleteClub =
-    (isLeader || user.role === "ADMIN") && isRegistrationPeriod;
+    (isLeader || user.role === "ADMIN") && openingStatus.isOpened;
   const canCreateForm = detail.club.type === "MAJOR_CLUB" && isLeader;
   const canViewApplications = isLeader || isManager;
   const formQuery = clubQueries.form(id);
@@ -138,7 +137,7 @@ const ClubDetailSection = ({
     .slice(0, SEARCH_RESULT_LIMIT);
 
   const handleApplyClick = () => {
-    if (autonomousApplyMutation.isPending) {
+    if (autonomousApplyMutation.isPending || hasClubApplication) {
       return;
     }
 
@@ -206,8 +205,15 @@ const ClubDetailSection = ({
               detail={detail}
               canDelete={canDeleteClub}
               isApplyPending={autonomousApplyMutation.isPending}
+              applyDisabledMessage={
+                hasClubApplication
+                  ? "동아리 신청은 1인 1회 신청입니다"
+                  : undefined
+              }
               onApplyClick={
-                isPending || isManager ? undefined : handleApplyClick
+                isPending || isManager || hasClubApplication
+                  ? undefined
+                  : handleApplyClick
               }
               formActionLabel={hasForm ? "폼 수정하기" : "폼 만들기"}
               onViewApplicationsClick={

--- a/src/features/club/ui/ClubFormCreateSection.tsx
+++ b/src/features/club/ui/ClubFormCreateSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import Club from "@/shared/asset/svg/Club";
 import TextField from "@/shared/ui/textField";
@@ -39,6 +40,8 @@ function ClubFormCreateSectionLoading() {
 function ClubFormCreateSectionError({
   resetErrorBoundary,
 }: QueryErrorFallbackProps) {
+  const router = useRouter();
+
   return (
     <div className="flex min-h-0 w-full flex-1 overflow-y-auto sm:px-8 lg:px-8 xl:px-10 xl:pb-6 2xl:px-18">
       <div className="bg-background-surface flex h-[520px] min-h-0 w-full flex-col items-center justify-center gap-3 rounded-2xl p-6">
@@ -46,15 +49,29 @@ function ClubFormCreateSectionError({
         <p className="text-text-1 text-main-text">
           동아리 정보를 불러오지 못했어요.
         </p>
-        <TextButton variant="outlined" size="fit" onClick={resetErrorBoundary}>
-          다시 시도
-        </TextButton>
+        <div className="flex gap-3">
+          <TextButton
+            variant="outlined"
+            size="fit"
+            onClick={resetErrorBoundary}
+          >
+            다시 시도
+          </TextButton>
+          <TextButton
+            variant="outlined"
+            size="fit"
+            onClick={() => router.back()}
+          >
+            뒤로가기
+          </TextButton>
+        </div>
       </div>
     </div>
   );
 }
 
 const ClubFormCreateSection = ({ id }: ClubFormCreateSectionProps) => {
+  const router = useRouter();
   const titleInputId = `club-form-title-${id}`;
   const descriptionInputId = `club-form-description-${id}`;
   const { data: detail } = useSuspenseQuery(clubQueries.detail(id));
@@ -92,6 +109,13 @@ const ClubFormCreateSection = ({ id }: ClubFormCreateSectionProps) => {
               ? "자율 동아리는 신청 폼을 만들 수 없어요."
               : "동아리 리더만 신청 폼을 만들 수 있어요."}
           </p>
+          <TextButton
+            variant="outlined"
+            size="fit"
+            onClick={() => router.back()}
+          >
+            뒤로가기
+          </TextButton>
         </div>
       </div>
     );
@@ -167,13 +191,21 @@ const ClubFormCreateSection = ({ id }: ClubFormCreateSectionProps) => {
             >
               질문 추가
             </button>
-            <TextButton
-              size="wide"
-              variant={canSubmit ? "filled" : "disabled"}
-              className="max-w-full"
-            >
-              폼 생성하기
-            </TextButton>
+            <div className="flex gap-3">
+              <TextButton
+                size="fit"
+                variant="outlined"
+                onClick={() => router.back()}
+              >
+                뒤로가기
+              </TextButton>
+              <TextButton
+                size="wide"
+                variant={canSubmit ? "filled" : "disabled"}
+              >
+                폼 생성하기
+              </TextButton>
+            </div>
           </div>
         </form>
       </div>

--- a/src/features/club/ui/ClubFormEditSection.tsx
+++ b/src/features/club/ui/ClubFormEditSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import Club from "@/shared/asset/svg/Club";
 import TextField from "@/shared/ui/textField";
@@ -30,6 +31,7 @@ interface ClubFormEditContentProps extends ClubFormEditSectionProps {
 }
 
 function ClubFormEditContent({ id, form }: ClubFormEditContentProps) {
+  const router = useRouter();
   const {
     title,
     description,
@@ -115,13 +117,18 @@ function ClubFormEditContent({ id, form }: ClubFormEditContentProps) {
         >
           질문 추가
         </button>
-        <TextButton
-          size="wide"
-          variant={canSubmit ? "filled" : "disabled"}
-          className="max-w-full"
-        >
-          폼 수정하기
-        </TextButton>
+        <div className="flex gap-3">
+          <TextButton
+            size="fit"
+            variant="outlined"
+            onClick={() => router.back()}
+          >
+            뒤로가기
+          </TextButton>
+          <TextButton size="wide" variant={canSubmit ? "filled" : "disabled"}>
+            폼 수정하기
+          </TextButton>
+        </div>
       </div>
     </form>
   );
@@ -142,6 +149,8 @@ function ClubFormEditSectionLoading() {
 function ClubFormEditSectionError({
   resetErrorBoundary,
 }: QueryErrorFallbackProps) {
+  const router = useRouter();
+
   return (
     <div className="flex min-h-0 w-full flex-1 overflow-y-auto sm:px-8 lg:px-8 xl:px-10 xl:pb-6 2xl:px-18">
       <div className="bg-background-surface flex h-[520px] min-h-0 w-full flex-col items-center justify-center gap-3 rounded-2xl p-6">
@@ -149,26 +158,45 @@ function ClubFormEditSectionError({
         <p className="text-text-1 text-main-text">
           동아리 신청 폼을 불러오지 못했어요.
         </p>
-        <TextButton variant="outlined" size="fit" onClick={resetErrorBoundary}>
-          다시 시도
-        </TextButton>
+        <div className="flex gap-3">
+          <TextButton
+            variant="outlined"
+            size="fit"
+            onClick={resetErrorBoundary}
+          >
+            다시 시도
+          </TextButton>
+          <TextButton
+            variant="outlined"
+            size="fit"
+            onClick={() => router.back()}
+          >
+            뒤로가기
+          </TextButton>
+        </div>
       </div>
     </div>
   );
 }
 
 function ClubFormEditSectionEmpty() {
+  const router = useRouter();
+
   return (
     <div className="flex min-h-0 w-full flex-1 overflow-y-auto sm:px-8 lg:px-8 xl:px-10 xl:pb-6 2xl:px-18">
       <div className="bg-background-surface flex h-[520px] min-h-0 w-full flex-col items-center justify-center gap-3 rounded-2xl p-6">
         <Club isActive={false} size={32} />
         <p className="text-text-1 text-main-text">수정할 신청 폼이 없어요.</p>
+        <TextButton variant="outlined" size="fit" onClick={() => router.back()}>
+          뒤로가기
+        </TextButton>
       </div>
     </div>
   );
 }
 
 const ClubFormEditSection = ({ id }: ClubFormEditSectionProps) => {
+  const router = useRouter();
   const { data: detail } = useSuspenseQuery(clubQueries.detail(id));
   const { data: form } = useSuspenseQuery({
     ...clubQueries.form(id),
@@ -189,6 +217,13 @@ const ClubFormEditSection = ({ id }: ClubFormEditSectionProps) => {
               ? "자율 동아리는 신청 폼을 수정할 수 없어요."
               : "동아리 리더만 신청 폼을 수정할 수 있어요."}
           </p>
+          <TextButton
+            variant="outlined"
+            size="fit"
+            onClick={() => router.back()}
+          >
+            뒤로가기
+          </TextButton>
         </div>
       </div>
     );

--- a/src/features/club/ui/ClubRegistrationSection.tsx
+++ b/src/features/club/ui/ClubRegistrationSection.tsx
@@ -5,17 +5,10 @@ import axios from "axios";
 import FileOff from "@/shared/asset/svg/FileOff";
 import TextField from "@/shared/ui/textField";
 import { TextButton } from "@/shared/ui/Button/TextButton";
-import ImageUpload from "@/shared/ui/ImageUpload";
 import Great from "@/shared/asset/svg/Great";
 import Back from "@/shared/asset/svg/Back";
-import Search from "@/shared/asset/svg/Search";
-import { useQuery } from "@tanstack/react-query";
 import { usePostClub } from "@/entities/club/api/clubQueries";
-import { userQueries } from "@/entities/user/api/userQueries";
 import type { RegistrationData } from "@/entities/club/model/club";
-import type { SearchUser } from "@/entities/user/model/user";
-import { StudentSearch } from "@/entities/user/ui/StudentSearch";
-import { SelectedStudent } from "@/entities/user/ui/SelectedStudent";
 import { toast } from "sonner";
 
 interface Props {
@@ -29,30 +22,16 @@ export default function ClubRegistrationSection({
 }: Props) {
   const [submitted, setSubmitted] = useState(false);
   const [formData, setFormData] = useState<RegistrationData>({
-    regType: null,
-    clubType: "MAJOR_CLUB",
-    clubName: "",
+    name: "",
+    type: "MAJOR_CLUB",
     status: "MAINTAIN",
-    leaderInfo: "",
-    clubDetail: "",
-    desiredTeacher: "",
-    clubImage: null,
+    description: "",
+    imageUrl: "",
+    maxMember: 0,
   });
-  const [memberName, setMemberName] = useState("");
-  const [selectedMembers, setSelectedMembers] = useState<SearchUser[]>([]);
 
   const { mutateAsync: postClubAsync } = usePostClub();
-  const { regType, clubName, leaderInfo, clubDetail } = formData;
-
-  const { data: usersData } = useQuery({
-    ...userQueries.list({ name: memberName || undefined }),
-    enabled: memberName.trim().length > 0,
-  });
-
-  const selectedIds = new Set(selectedMembers.map((m) => m.id));
-  const filteredMembers = (usersData?.content ?? []).filter(
-    (user) => !selectedIds.has(user.id),
-  );
+  const { name, type, description, imageUrl, maxMember } = formData;
 
   const handleChange = <K extends keyof RegistrationData>(
     key: K,
@@ -61,21 +40,16 @@ export default function ClubRegistrationSection({
     setFormData((prev) => ({ ...prev, [key]: value }));
   };
 
-  const isBasicFilled = !!(clubName && regType && leaderInfo && clubDetail);
-  const canSubmit =
-    isBasicFilled && (regType !== "NEW" || selectedMembers.length > 0);
+  const canSubmit = !!name.trim() && !!description.trim() && maxMember >= 0;
 
   const handleSubmit = async () => {
     const requestBody = {
-      name: clubName,
-      type:
-        regType === "NEW"
-          ? ("MAJOR_CLUB" as const)
-          : ("AUTONOMOUS_CLUB" as const),
-      status: "MAINTAIN" as const,
-      description: clubDetail,
-      imageUrl: "",
-      maxMember: selectedMembers.length || 1,
+      name,
+      type,
+      status: formData.status,
+      description,
+      imageUrl,
+      maxMember,
     };
 
     const promise = postClubAsync(requestBody);
@@ -124,27 +98,27 @@ export default function ClubRegistrationSection({
     >
       {!compact && (
         <div className="flex h-[762px] min-h-0 flex-1 flex-col items-center justify-center">
-        {!submitted ? (
-          <>
-            <FileOff />
-            <span className="text-sub-2 text-text-1 mt-4">
-              지금은 동아리 개설 기간입니다
-            </span>
-          </>
-        ) : (
-          <>
-            <Great />
-            <span className="text-sub-2 text-text-1 mt-4">
-              동아리 개설이 성공적으로 완료 되었습니다
-            </span>
-            <button
-              onClick={onGoBackToList}
-              className="text-text-1 text-sub-2 mt-4 flex cursor-pointer items-center gap-2 underline hover:opacity-80"
-            >
-              돌아가기 <Back direction="right" />
-            </button>
-          </>
-        )}
+          {!submitted ? (
+            <>
+              <FileOff />
+              <span className="text-sub-2 text-text-1 mt-4">
+                지금은 동아리 개설 기간입니다
+              </span>
+            </>
+          ) : (
+            <>
+              <Great />
+              <span className="text-sub-2 text-text-1 mt-4">
+                동아리 개설이 성공적으로 완료 되었습니다
+              </span>
+              <button
+                onClick={onGoBackToList}
+                className="text-text-1 text-sub-2 mt-4 flex cursor-pointer items-center gap-2 underline hover:opacity-80"
+              >
+                돌아가기 <Back direction="right" />
+              </button>
+            </>
+          )}
         </div>
       )}
 
@@ -158,40 +132,31 @@ export default function ClubRegistrationSection({
             <span className="text-text-3">동아리명 (추후 변경 가능)</span>
             <TextField
               placeholder="동아리명을 적어주세요"
-              onChange={(e) => handleChange("clubName", e.target.value)}
-              value={clubName}
+              onChange={(e) => handleChange("name", e.target.value)}
+              value={name}
             />
           </div>
 
           <div className="flex flex-col gap-1">
-            <span className="text-text-3">유지, 신설 여부</span>
+            <span className="text-text-3">동아리 유형</span>
             <div className="flex w-full gap-1">
               <TextButton
-                variant={regType === "NEW" ? "filled" : "outlined"}
+                variant={type === "MAJOR_CLUB" ? "filled" : "outlined"}
                 size="fit"
                 className="flex-1"
-                onClick={() => handleChange("regType", "NEW")}
+                onClick={() => handleChange("type", "MAJOR_CLUB")}
               >
-                신설
+                정규
               </TextButton>
               <TextButton
-                variant={regType === "MAINTAIN" ? "filled" : "outlined"}
+                variant={type === "AUTONOMOUS_CLUB" ? "filled" : "outlined"}
                 size="fit"
                 className="flex-1"
-                onClick={() => handleChange("regType", "MAINTAIN")}
+                onClick={() => handleChange("type", "AUTONOMOUS_CLUB")}
               >
-                유지
+                자율
               </TextButton>
             </div>
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <span className="text-text-3 font-medium">부장 이름/학번</span>
-            <TextField
-              placeholder="ex. 1101 김**"
-              onChange={(e) => handleChange("leaderInfo", e.target.value)}
-              value={leaderInfo}
-            />
           </div>
 
           <div className="flex flex-col gap-1">
@@ -200,62 +165,37 @@ export default function ClubRegistrationSection({
             </span>
             <textarea
               placeholder="동아리 활동 내용 및 소개를 적어주세요"
-              onChange={(e) => handleChange("clubDetail", e.target.value)}
-              value={clubDetail}
+              onChange={(e) => handleChange("description", e.target.value)}
+              value={description}
               maxLength={500}
               className="border-sub-2 bg-background-surface text-main-text h-32 w-full resize-none rounded-lg border px-4 py-3 outline-none"
             />
             <span className="text-sub-2 text-right text-xs">
-              {clubDetail.length}/500
+              {description.length}/500
             </span>
           </div>
 
           <div className="flex flex-col gap-1">
-            <span className="text-text-3 font-medium">
-              배정 희망 전공 선생님 (없으면 공란)
-            </span>
+            <span className="text-text-3 font-medium">대표 이미지 URL</span>
             <TextField
-              placeholder="희망 전공 선생님을 적어주세요"
-              onChange={(e) => handleChange("desiredTeacher", e.target.value)}
-              value={formData.desiredTeacher}
+              placeholder="이미지 URL을 입력해주세요"
+              onChange={(e) => handleChange("imageUrl", e.target.value)}
+              value={imageUrl}
             />
           </div>
 
-          {regType === "NEW" && (
-            <div className="flex flex-col gap-2">
-              <span className="text-text-3 font-medium">부원 추가</span>
-              <div className="relative">
-                <TextField
-                  placeholder="이름, 학번을 입력해주세요"
-                  value={memberName}
-                  onChange={(e) => setMemberName(e.target.value)}
-                  rightIcon={<Search />}
-                />
-                <div className="absolute top-full right-0 left-0 z-10 mt-1">
-                  <StudentSearch
-                    filteredStudents={filteredMembers}
-                    isFull={false}
-                    onSelect={(student) => {
-                      setSelectedMembers((prev) => [...prev, student]);
-                      setMemberName("");
-                    }}
-                  />
-                </div>
-              </div>
-              <SelectedStudent
-                selectedStudents={selectedMembers}
-                onRemoveStudent={(num) =>
-                  setSelectedMembers((prev) =>
-                    prev.filter((s) => s.studentNumber !== num),
-                  )
-                }
-              />
-            </div>
-          )}
-
-          <ImageUpload
-            onImageChange={(file) => handleChange("clubImage", file)}
-          />
+          <div className="flex flex-col gap-1">
+            <span className="text-text-3 font-medium">최대 인원</span>
+            <TextField
+              type="number"
+              min={0}
+              placeholder="최대 인원을 입력해주세요"
+              onChange={(e) =>
+                handleChange("maxMember", Number(e.target.value))
+              }
+              value={maxMember}
+            />
+          </div>
 
           <TextButton
             size="fit"

--- a/src/features/club/ui/ClubRegistrationSection.tsx
+++ b/src/features/club/ui/ClubRegistrationSection.tsx
@@ -20,9 +20,13 @@ import { toast } from "sonner";
 
 interface Props {
   onGoBackToList?: () => void;
+  compact?: boolean;
 }
 
-export default function ClubRegistrationSection({ onGoBackToList }: Props) {
+export default function ClubRegistrationSection({
+  onGoBackToList,
+  compact = false,
+}: Props) {
   const [submitted, setSubmitted] = useState(false);
   const [formData, setFormData] = useState<RegistrationData>({
     regType: null,
@@ -93,9 +97,33 @@ export default function ClubRegistrationSection({ onGoBackToList }: Props) {
     });
   };
 
+  if (compact && submitted) {
+    return (
+      <div className="flex w-full flex-col items-center justify-center gap-4 py-12">
+        <Great />
+        <span className="text-sub-2 text-text-1 text-center">
+          동아리 개설이 성공적으로 완료 되었습니다
+        </span>
+        <button
+          onClick={onGoBackToList}
+          className="text-text-1 text-sub-2 flex cursor-pointer items-center gap-2 underline hover:opacity-80"
+        >
+          돌아가기 <Back direction="right" />
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex h-full min-h-0 flex-1 flex-col gap-10 lg:flex-row">
-      <div className="flex h-[762px] min-h-0 flex-1 flex-col items-center justify-center">
+    <div
+      className={
+        compact
+          ? "flex w-full flex-col"
+          : "flex h-full min-h-0 flex-1 flex-col gap-10 lg:flex-row"
+      }
+    >
+      {!compact && (
+        <div className="flex h-[762px] min-h-0 flex-1 flex-col items-center justify-center">
         {!submitted ? (
           <>
             <FileOff />
@@ -117,10 +145,15 @@ export default function ClubRegistrationSection({ onGoBackToList }: Props) {
             </button>
           </>
         )}
-      </div>
+        </div>
+      )}
 
-      <div className="flex w-full flex-col lg:w-[330px]">
-        <div className="flex flex-col gap-4 overflow-y-auto">
+      <div
+        className={
+          compact ? "flex w-full flex-col" : "flex w-full flex-col lg:w-[330px]"
+        }
+      >
+        <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
             <span className="text-text-3">동아리명 (추후 변경 가능)</span>
             <TextField

--- a/src/features/club/ui/ClubSection.tsx
+++ b/src/features/club/ui/ClubSection.tsx
@@ -2,11 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import {
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import Club from "@/shared/asset/svg/Club";
 import Back from "@/shared/asset/svg/Back";
 import Smile from "@/shared/asset/svg/Smile";
@@ -53,7 +49,7 @@ function ClubSearchSkeleton() {
 
 function ClubSectionLoading() {
   return (
-    <div className="flex min-h-0 w-full flex-1 overflow-y-auto sm:px-8 lg:px-8 xl:px-10 xl:pb-6 2xl:px-18">
+    <div className="flex min-h-0 w-full flex-1 sm:px-8 lg:px-8 xl:px-10 xl:pb-6 2xl:px-18">
       <div className="bg-background-surface flex h-fit min-h-0 w-full flex-col gap-4 rounded-2xl p-6">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -67,7 +63,7 @@ function ClubSectionLoading() {
         </div>
 
         <div className="flex h-full min-h-0 flex-1 flex-col gap-4 lg:flex-row lg:items-stretch">
-          <div className="order-2 min-h-0 flex-1 overflow-y-auto lg:order-1 lg:h-full lg:overflow-y-scroll lg:pr-2">
+          <div className="order-2 min-h-0 flex-1 lg:order-1 lg:h-full lg:pr-2">
             <div className="grid grid-cols-[repeat(auto-fill,minmax(263px,1fr))] gap-4">
               {Array.from({ length: 8 }).map((_, index) => (
                 <ClubCardSkeleton key={index} />
@@ -86,7 +82,7 @@ function ClubSectionLoading() {
 
 function ClubSectionError({ resetErrorBoundary }: QueryErrorFallbackProps) {
   return (
-    <div className="flex min-h-0 w-full flex-1 overflow-y-auto sm:px-8 lg:px-8 xl:px-10 xl:pb-6 2xl:px-18">
+    <div className="flex min-h-0 w-full flex-1 sm:px-8 lg:px-8 xl:px-10 xl:pb-6 2xl:px-18">
       <div className="bg-background-surface flex h-[520px] min-h-0 w-full flex-col items-center justify-center gap-3 rounded-2xl p-6">
         <Club isActive={false} size={32} />
         <p className="text-text-1 text-main-text">
@@ -104,7 +100,7 @@ const ClubSection = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
 
-  const [viewMode, setViewMode] = useState<"form" | "list">("form");
+  const [viewMode, setViewMode] = useState<"form" | "list">("list");
   const [query, setQuery] = useState("");
   const [searchValue, setSearchValue] = useState("");
 
@@ -119,7 +115,6 @@ const ClubSection = () => {
 
   const filteredClubs = filterClubs({
     clubs,
-    openingStatus,
     searchValue,
   });
 
@@ -134,14 +129,39 @@ const ClubSection = () => {
   };
 
   const handleSearch = () => setSearchValue(query);
-  const shouldShowRegistrationForm =
-    openingStatus.isOpened &&
-    !hasClubApplication &&
-    !isManager &&
-    viewMode !== "list";
+  const canRegisterClub = openingStatus.isOpened;
+  const clubModeToggle = (
+    <div className="flex w-full gap-1">
+      <TextButton
+        variant={viewMode === "list" ? "filled" : "outlined"}
+        size="fit"
+        className="flex-1"
+        onClick={() => setViewMode("list")}
+      >
+        동아리 검색
+      </TextButton>
+      <TextButton
+        variant={
+          viewMode === "form" && canRegisterClub
+            ? "filled"
+            : canRegisterClub
+              ? "outlined"
+              : "disabled"
+        }
+        size="fit"
+        className="flex-1"
+        disabled={!canRegisterClub}
+        onClick={() => {
+          if (canRegisterClub) setViewMode("form");
+        }}
+      >
+        개설 신청
+      </TextButton>
+    </div>
+  );
 
   return (
-    <div className="flex min-h-0 w-full flex-1 overflow-y-auto sm:px-8 lg:px-8 xl:px-10 xl:pb-6 2xl:px-18">
+    <div className="flex min-h-0 w-full flex-1 sm:px-8 lg:px-8 xl:px-10 xl:pb-6 2xl:px-18">
       <div className="bg-background-surface flex h-fit min-h-0 w-full flex-col gap-4 rounded-2xl p-6">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -156,36 +176,42 @@ const ClubSection = () => {
           </div>
         </div>
 
-        {shouldShowRegistrationForm ? (
-          <ClubRegistrationSection onGoBackToList={handleGoBackToList} />
-        ) : (
-          <div className="flex h-full min-h-0 flex-1 flex-col gap-4 lg:flex-row lg:items-stretch">
-            <div className="order-2 min-h-0 flex-1 overflow-y-auto lg:order-1 lg:h-full lg:overflow-y-scroll lg:pr-2">
-              <div className="flex flex-col gap-6">
-                <div className="grid grid-cols-[repeat(auto-fill,minmax(263px,1fr))] gap-4">
-                  {filteredClubs.map((club) => (
-                    <ClubCard
-                      key={club.id}
-                      club={club}
-                      onClick={() => router.push(`/club/${club.id}`)}
-                    />
-                  ))}
-                </div>
-                {isManager && <ClubOpeningRequestSection />}
-              </div>
-            </div>
-            <div className="order-1 flex flex-col items-center justify-center lg:order-2 lg:w-[330px] lg:shrink-0 lg:self-stretch">
-              {!openingStatus.isOpened && (
-                <div className="mb-auto w-full">
-                  <ClubSearch
-                    query={query}
-                    setQuery={handleQueryChange}
-                    onSearch={handleSearch}
+        <div className="flex h-full min-h-0 flex-1 flex-col gap-4 lg:flex-row lg:items-stretch">
+          <div className="order-2 min-h-0 flex-1 lg:order-1 lg:h-full lg:pr-2">
+            <div className="flex flex-col gap-6">
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(263px,1fr))] gap-4">
+                {filteredClubs.map((club) => (
+                  <ClubCard
+                    key={club.id}
+                    club={club}
+                    onClick={() => router.push(`/club/${club.id}`)}
                   />
-                </div>
-              )}
+                ))}
+              </div>
+              {isManager && <ClubOpeningRequestSection />}
+            </div>
+          </div>
+          <div className="order-1 flex flex-col items-center justify-center lg:order-2 lg:w-[330px] lg:shrink-0 lg:self-stretch">
+            <div className="mb-auto flex w-full flex-col gap-4">
+              {clubModeToggle}
 
-              {openingStatus.isOpened && hasClubApplication && (
+              {viewMode === "form" && canRegisterClub ? (
+                <ClubRegistrationSection
+                  compact
+                  onGoBackToList={handleGoBackToList}
+                />
+              ) : (
+                <ClubSearch
+                  query={query}
+                  setQuery={handleQueryChange}
+                  onSearch={handleSearch}
+                />
+              )}
+            </div>
+
+            {viewMode === "list" &&
+              openingStatus.isOpened &&
+              hasClubApplication && (
                 <div className="flex flex-col items-center justify-center gap-4">
                   <Smile />
                   <p className="text-sub-2 text-text-1">
@@ -200,9 +226,8 @@ const ClubSection = () => {
                   </button>
                 </div>
               )}
-            </div>
           </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/src/features/club/ui/ClubSection.tsx
+++ b/src/features/club/ui/ClubSection.tsx
@@ -110,7 +110,7 @@ const ClubSection = () => {
 
   const { data } = useSuspenseQuery(clubQueries.list());
   const { data: user } = useSuspenseQuery(userQueries.me());
-  const { data: isRegistrationPeriod = false } = useQuery(
+  const { data: openingStatus } = useSuspenseQuery(
     clubQueries.openingStatus(),
   );
   const isManager = user.role === "ADMIN" || user.role === "STUDENT_COUNCIL";
@@ -119,7 +119,7 @@ const ClubSection = () => {
 
   const filteredClubs = filterClubs({
     clubs,
-    isRegistrationPeriod,
+    openingStatus,
     searchValue,
   });
 
@@ -135,7 +135,7 @@ const ClubSection = () => {
 
   const handleSearch = () => setSearchValue(query);
   const shouldShowRegistrationForm =
-    isRegistrationPeriod &&
+    openingStatus.isOpened &&
     !hasClubApplication &&
     !isManager &&
     viewMode !== "list";
@@ -175,7 +175,7 @@ const ClubSection = () => {
               </div>
             </div>
             <div className="order-1 flex flex-col items-center justify-center lg:order-2 lg:w-[330px] lg:shrink-0 lg:self-stretch">
-              {!isRegistrationPeriod && (
+              {!openingStatus.isOpened && (
                 <div className="mb-auto w-full">
                   <ClubSearch
                     query={query}
@@ -185,7 +185,7 @@ const ClubSection = () => {
                 </div>
               )}
 
-              {isRegistrationPeriod && hasClubApplication && (
+              {openingStatus.isOpened && hasClubApplication && (
                 <div className="flex flex-col items-center justify-center gap-4">
                   <Smile />
                   <p className="text-sub-2 text-text-1">

--- a/src/features/club/ui/ClubSection.tsx
+++ b/src/features/club/ui/ClubSection.tsx
@@ -106,9 +106,7 @@ const ClubSection = () => {
 
   const { data } = useSuspenseQuery(clubQueries.list());
   const { data: user } = useSuspenseQuery(userQueries.me());
-  const { data: openingStatus } = useSuspenseQuery(
-    clubQueries.openingStatus(),
-  );
+  const { data: openingStatus } = useSuspenseQuery(clubQueries.openingStatus());
   const isManager = user.role === "ADMIN" || user.role === "STUDENT_COUNCIL";
   const hasClubApplication = user.hasClubApplication ?? false;
   const clubs = data.clubs;

--- a/src/features/club/ui/ClubSection.tsx
+++ b/src/features/club/ui/ClubSection.tsx
@@ -4,8 +4,6 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import Club from "@/shared/asset/svg/Club";
-import Back from "@/shared/asset/svg/Back";
-import Smile from "@/shared/asset/svg/Smile";
 import ClubCard from "@/entities/club/ui/ClubCard";
 import { clubQueries } from "@/entities/club/api/clubQueries";
 import { userQueries } from "@/entities/user/api/userQueries";
@@ -108,7 +106,6 @@ const ClubSection = () => {
   const { data: user } = useSuspenseQuery(userQueries.me());
   const { data: openingStatus } = useSuspenseQuery(clubQueries.openingStatus());
   const isManager = user.role === "ADMIN" || user.role === "STUDENT_COUNCIL";
-  const hasClubApplication = user.hasClubApplication ?? false;
   const clubs = data.clubs;
 
   const filteredClubs = filterClubs({
@@ -206,24 +203,6 @@ const ClubSection = () => {
                 />
               )}
             </div>
-
-            {viewMode === "list" &&
-              openingStatus.isOpened &&
-              hasClubApplication && (
-                <div className="flex flex-col items-center justify-center gap-4">
-                  <Smile />
-                  <p className="text-sub-2 text-text-1">
-                    동아리 신청은 1인 1회 신청입니다
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => setViewMode("form")}
-                    className="text-sub-2 text-text-1 flex cursor-pointer items-center gap-1"
-                  >
-                    내 동아리 수정하기 <Back direction="right" />
-                  </button>
-                </div>
-              )}
           </div>
         </div>
       </div>

--- a/src/shared/asset/svg/Smile.tsx
+++ b/src/shared/asset/svg/Smile.tsx
@@ -1,3 +1,6 @@
+/**
+ * @deprecated
+ */
 export default function Smile() {
   return (
     <svg

--- a/src/widgets/header/ui/clock.tsx
+++ b/src/widgets/header/ui/clock.tsx
@@ -27,7 +27,7 @@ export function Clock() {
   }, []);
 
   return (
-    <div className="bg-background-surface flex items-end gap-2 rounded-lg p-2">
+    <div className="bg-background-surface flex items-end gap-2 rounded-lg px-5 py-2">
       <span className="text-title-2 text-main-text tabular-nums">{time}</span>
       <span className="text-text-4 text-sub-1">{date}</span>
     </div>


### PR DESCRIPTION
## #️⃣연관된 이슈


#104

## 📝작업 내용

### ClubOpeningStatus 구조 개선
- `getClubOpeningStatus()` API 응답을 boolean에서 `ClubOpeningStatus` 타입으로 변경
- 개설/폐쇠 시작일, 종료일 정보 포함
- 실제 API 응답 구조에 맞춘 타입 정의

### 동아리 신청 중복 방지 UI
- **ClubDetail** (`entities/club/ui`): `applyDisabledMessage` prop 추가
- 사용자가 이미 동아리를 신청한 경우 "동아리 신청은 1인 1회 신청입니다" 메시지 표시
- Smile 아이콘과 함께 비활성화 상태 시각화

신청 기간이 아니여서 테스트를 진행하지 못 하였습니다.

### RegistrationData 타입 정규화
- 레거시 필드 제거: `regType`, `leaderInfo`, `desiredTeacher`, `clubImage`
- API 스펙에 맞춘 필드 추가: `name`, `type`, `description`, `imageUrl`, `maxMember`
- **ClubRegistrationSection**에서 선생님 배정, 부원 추가 기능 제거 및 단순화

### ClubSection 레이아웃 개선
- 초기 상태를 `form`에서 `list`로 변경
- 검색/개설 신청 모드를 명시적 토글 버튼으로 구현
- 개설 기간 종료 후 개설 신청 버튼 비활성화
- **ClubRegistrationSection**에 `compact` prop 추가하여 모달/사이드팬 레이아웃 지원

### 검색
<img width="3420" height="2146" alt="image" src="https://github.com/user-attachments/assets/603c07b6-038a-4592-8b6a-b0c3f9364669" />

### 개설 신청
<img width="3420" height="2146" alt="image" src="https://github.com/user-attachments/assets/dff7a530-a6c2-488c-93c6-29d76ddaa593" />

### 기타 개선
- `filterClubs()` 함수에서 `isRegistrationPeriod` 조건 제거
- **ClubDetailSection**: `openingStatus.isOpened` 활용한 삭제 권한 검증
- **Header Clock**: 패딩 조정 (`p-2` → `px-5 py-2`)