### PR TITLE
fix: 홈베이스 예약일 요청값 추가

### DIFF
--- a/src/entities/homebase/model/homebase.ts
+++ b/src/entities/homebase/model/homebase.ts
@@ -13,6 +13,7 @@ export interface HomebaseReservation {
 }
 
 export interface HomebaseApplyRequest {
+  reservationDate: string;
   startPeriod: number;
   endPeriod: number;
   reason: string;

--- a/src/features/homebase/lib/homebaseReservationPolicy.ts
+++ b/src/features/homebase/lib/homebaseReservationPolicy.ts
@@ -35,6 +35,7 @@ interface ReservedTableMembersParams {
 }
 
 interface HomebaseApplyRequestParams {
+  reservationDate?: Date;
   startPeriod: number;
   endPeriod: number;
   reason: string;
@@ -43,6 +44,14 @@ interface HomebaseApplyRequestParams {
 }
 
 const floorOrder: Record<string, number> = { "2F": 0, "3F": 1, "4F": 2 };
+
+function formatReservationDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
 
 export function getPeriodNumber(period: string, periods: string[]): number {
   return 8 + periods.indexOf(period);
@@ -204,6 +213,7 @@ export function getMyHomebaseReservations(
 }
 
 export function createHomebaseApplyRequest({
+  reservationDate = new Date(),
   startPeriod,
   endPeriod,
   reason,
@@ -220,6 +230,7 @@ export function createHomebaseApplyRequest({
     : [];
 
   return {
+    reservationDate: formatReservationDate(reservationDate),
     startPeriod,
     endPeriod,
     reason,

--- a/src/features/homebase/lib/homebaseReservationPolicy.ts
+++ b/src/features/homebase/lib/homebaseReservationPolicy.ts
@@ -35,7 +35,7 @@ interface ReservedTableMembersParams {
 }
 
 interface HomebaseApplyRequestParams {
-  reservationDate?: Date;
+  reservationDate: string;
   startPeriod: number;
   endPeriod: number;
   reason: string;
@@ -44,14 +44,6 @@ interface HomebaseApplyRequestParams {
 }
 
 const floorOrder: Record<string, number> = { "2F": 0, "3F": 1, "4F": 2 };
-
-function formatReservationDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-
-  return `${year}-${month}-${day}`;
-}
 
 export function getPeriodNumber(period: string, periods: string[]): number {
   return 8 + periods.indexOf(period);
@@ -213,7 +205,7 @@ export function getMyHomebaseReservations(
 }
 
 export function createHomebaseApplyRequest({
-  reservationDate = new Date(),
+  reservationDate,
   startPeriod,
   endPeriod,
   reason,
@@ -230,7 +222,7 @@ export function createHomebaseApplyRequest({
     : [];
 
   return {
-    reservationDate: formatReservationDate(reservationDate),
+    reservationDate,
     startPeriod,
     endPeriod,
     reason,

--- a/src/features/homebase/model/useHomebaseReservation.ts
+++ b/src/features/homebase/model/useHomebaseReservation.ts
@@ -7,11 +7,13 @@ import { useHomebasePeriodSelection } from "@/features/homebase/model/useHomebas
 import { useHomebaseReservationActions } from "@/features/homebase/model/useHomebaseReservationActions";
 import { useHomebaseReservationData } from "@/features/homebase/model/useHomebaseReservationData";
 import { useHomebaseStudentSelection } from "@/features/homebase/model/useHomebaseStudentSelection";
+import { formatDateParam } from "@/shared/lib/date";
 
 export function useHomebaseReservation() {
   const [selectedFloor, setSelectedFloor] = useState("2F");
   const [selectedTable, setSelectedTable] = useState<string | null>(null);
   const [reason, setReason] = useState("");
+  const [reservationDate] = useState(() => formatDateParam(new Date()));
   const {
     selectedStartPeriod,
     selectedStartNum,
@@ -109,6 +111,7 @@ export function useHomebaseReservation() {
       selectedStartPeriod,
       selectedStartNum,
       selectedEndNum,
+      reservationDate,
       reason,
       reservations,
       currentUser,

--- a/src/features/homebase/model/useHomebaseReservationActions.ts
+++ b/src/features/homebase/model/useHomebaseReservationActions.ts
@@ -24,6 +24,7 @@ interface UseHomebaseReservationActionsParams {
   selectedStartPeriod: string;
   selectedStartNum: number;
   selectedEndNum: number;
+  reservationDate: string;
   reason: string;
   reservations: HomebaseReservation[];
   currentUser?: User | null;
@@ -37,6 +38,7 @@ export function useHomebaseReservationActions({
   selectedStartPeriod,
   selectedStartNum,
   selectedEndNum,
+  reservationDate,
   reason,
   reservations,
   currentUser,
@@ -111,6 +113,7 @@ export function useHomebaseReservationActions({
     applyMutation.mutate({
       homebaseId,
       body: createHomebaseApplyRequest({
+        reservationDate,
         startPeriod: selectedStartNum,
         endPeriod: selectedEndNum,
         reason,

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -1,0 +1,7 @@
+export function formatDateParam(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}

--- a/src/widgets/main/ui/MealCard.tsx
+++ b/src/widgets/main/ui/MealCard.tsx
@@ -11,6 +11,7 @@ import {
   type QueryErrorFallbackProps,
 } from "@/shared/ui/QueryErrorBoundary";
 import { Skeleton } from "@/shared/ui/Skeleton";
+import { formatDateParam } from "@/shared/lib/date";
 
 const DAYS = ["일", "월", "화", "수", "목", "금", "토"];
 const MEAL_TYPES = ["조식", "중식", "석식"] as const;
@@ -36,13 +37,6 @@ function formatDisplayDate(date: Date): string {
   const dd = String(date.getDate()).padStart(2, "0");
   const day = DAYS[date.getDay()];
   return `${yy}.${mm}.${dd} (${day})`;
-}
-
-function formatParamDate(date: Date): string {
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, "0");
-  const dd = String(date.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
 }
 
 function MealCardLoading() {
@@ -97,7 +91,7 @@ const MealCard = () => {
 
   const currentDate = new Date();
   currentDate.setDate(currentDate.getDate() + offset);
-  const dateStr = formatParamDate(currentDate);
+  const dateStr = formatDateParam(currentDate);
 
   const { data: meals } = useSuspenseQuery(neisQueries.meals(dateStr));
 

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -14,6 +14,7 @@ import {
   type QueryErrorFallbackProps,
 } from "@/shared/ui/QueryErrorBoundary";
 import { Skeleton } from "@/shared/ui/Skeleton";
+import { formatDateParam } from "@/shared/lib/date";
 
 const DAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
@@ -42,13 +43,6 @@ function formatDisplayDate(date: Date): string {
   const dd = String(date.getDate()).padStart(2, "0");
   const day = DAYS[date.getDay()];
   return `${yy}.${mm}.${dd} (${day})`;
-}
-
-function formatParamDate(date: Date): string {
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, "0");
-  const dd = String(date.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
 }
 
 function TimeTableCardLoading() {
@@ -106,7 +100,7 @@ const TimeTableCard = () => {
 
   const currentDate = new Date();
   currentDate.setDate(currentDate.getDate() + offset);
-  const dateStr = formatParamDate(currentDate);
+  const dateStr = formatDateParam(currentDate);
 
   const currentPeriod = offset === 0 ? getCurrentPeriod() : null;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- `entities/homebase`의 홈베이스 신청 요청 타입에 `reservationDate` 필드를 추가했습니다.
- `features/homebase`의 신청 요청 생성 로직에서 예약일을 `YYYY-MM-DD` 형식으로 변환해 요청값에 포함하도록 수정했습니다.