### PR TITLE
refactor: 로그인 및 토큰 만료 처리 개선

### DIFF
--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -40,11 +40,10 @@ export async function POST(request: NextRequest) {
       const { data, status } = error.response;
       const body = data ?? fallbackBody;
 
-      if (status === HttpStatusCode.BadRequest) {
-        return NextResponse.json(body, { status });
-      }
-
-      if (status === HttpStatusCode.Unauthorized) {
+      if (
+        status === HttpStatusCode.BadRequest ||
+        status === HttpStatusCode.Unauthorized
+      ) {
         const res = NextResponse.json(body, { status });
         res.cookies.delete("refresh_token");
         return res;

--- a/app/callback/page.tsx
+++ b/app/callback/page.tsx
@@ -49,9 +49,9 @@ function CallbackInner() {
 
   if (status === "error") {
     return (
-      <div className="bg-background flex h-screen items-center justify-center">
-        <div className="bg-background-surface flex w-[360px] flex-col gap-4 rounded-2xl p-6">
-          <div className="flex flex-col gap-1">
+      <div className="bg-background flex min-h-screen items-center justify-center px-5">
+        <div className="bg-background-surface flex w-full max-w-[380px] flex-col gap-5 rounded-2xl p-7 shadow-[0_18px_60px_rgba(0,0,0,0.08)] dark:shadow-none">
+          <div className="flex flex-col gap-2">
             <h1 className="text-title-3 text-main-text">로그인 실패</h1>
             <p className="text-text-3 text-sub-1">{errorMessage}</p>
           </div>
@@ -68,9 +68,10 @@ function CallbackInner() {
   }
 
   return (
-    <div className="bg-background flex h-screen items-center justify-center">
-      <div className="bg-background-surface text-title-3 text-main-text rounded-2xl p-12">
-        로그인 처리 중...
+    <div className="bg-background flex min-h-screen items-center justify-center">
+      <div className="flex items-center gap-3">
+        <span className="bg-p-1 size-2.5 animate-pulse rounded-full" />
+        <p className="text-title-3 text-main-text">로그인 처리 중...</p>
       </div>
     </div>
   );
@@ -80,8 +81,11 @@ export default function Callback() {
   return (
     <Suspense
       fallback={
-        <div className="bg-background text-text-3 text-main-text flex h-screen items-center justify-center">
-          로딩 중...
+        <div className="bg-background flex min-h-screen items-center justify-center">
+          <div className="flex items-center gap-3">
+            <span className="bg-p-1 size-2.5 animate-pulse rounded-full" />
+            <p className="text-text-3 text-main-text">로딩 중...</p>
+          </div>
         </div>
       }
     >

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* 1. 기본값 및 라이트 모드 설정 */
 :root,
 .light {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,9 +5,9 @@ import "./globals.css";
 import Providers from "./providers";
 
 export const metadata: Metadata = {
-  title: "플러딩 | 광주소마고 통합 관리 시스템",
+  title: "플러딩",
   description:
-    "광주소마고 통합 관리 시스템 플러딩의 공식 웹사이트입니다. 플러딩은 광주소마고의 기숙사, 홈베이스, 동아리 관리와 같은 다양한 기능을 통합, 제공하여 학생들의 편리한 생활을 지원합니다",
+    "플러딩은 GSM의 학교생활과 기숙사 생활을 하나로 연결하는 통합 관리 시스템입니다. 동아리 개설과 모집, 자습 관리, 안마의자 예약, 기상음악 신청, AI 추천과 챗봇 기능을 한 곳에서 제공해 학생들의 편리한 생활을 지원합니다.",
 };
 
 export default function RootLayout({

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Logo from "@/shared/asset/svg/Logo";
-import { TextButton } from "@/shared/ui/Button/TextButton";
+import { DataGsmLoginButton } from "@/shared/ui/Button/DataGsmLoginButton";
 import { useOAuth } from "@themoment-team/datagsm-oauth-react";
 
 export default function Signin() {
@@ -27,18 +27,17 @@ export default function Signin() {
   };
 
   return (
-    <div className="bg-background flex h-screen items-center justify-center overflow-hidden">
-      <div className="bg-background-surface flex h-fit w-fit flex-col items-center gap-6 rounded-2xl px-8 py-13">
-        <Logo />
-        <div className="flex flex-col items-center gap-3">
-          <TextButton
-            variant={isLoggingIn ? "disabled" : "filled"}
-            size="wide"
-            disabled={isLoggingIn}
-            onClick={handleLogin}
-          >
-            {isLoggingIn ? "로그인 중" : "Data GSM으로 로그인"}
-          </TextButton>
+    <div className="bg-background flex min-h-screen items-center justify-center overflow-hidden px-5 py-10">
+      <div className="bg-background-surface flex min-h-[430px] w-full max-w-[480px] flex-col items-center justify-center gap-10 rounded-2xl px-8 py-12 shadow-[0_18px_60px_rgba(0,0,0,0.08)] dark:shadow-none">
+        <div className="flex flex-col items-center gap-8">
+          <Logo width={265} height={72} />
+          <div className="flex flex-col items-center gap-3 text-center">
+            <h1 className="text-title-1 text-main-text">로그인</h1>
+            <p className="text-text-3 text-sub-1">GSM 통합 관리 시스템</p>
+          </div>
+        </div>
+        <div className="flex min-h-[62px] flex-col items-center gap-3">
+          <DataGsmLoginButton disabled={isLoggingIn} onClick={handleLogin} />
           {errorMessage && (
             <p className="text-caption-2 text-negative w-[330px] text-center">
               {errorMessage}

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -27,22 +27,16 @@ export default function Signin() {
   };
 
   return (
-    <main className="bg-background relative isolate flex min-h-screen items-center justify-center overflow-hidden px-5 py-12 before:absolute before:inset-0 before:-z-20 before:bg-[linear-gradient(135deg,var(--background)_0%,var(--color-p-2)_52%,var(--background-surface)_100%)] after:absolute after:inset-0 after:-z-10 after:bg-[radial-gradient(circle_at_20%_20%,var(--color-p-3)_0_1px,transparent_1px),radial-gradient(circle_at_78%_72%,var(--color-sub-3)_0_1px,transparent_1px)] after:bg-[length:34px_34px,48px_48px] after:opacity-45 dark:before:bg-[linear-gradient(135deg,var(--background)_0%,var(--color-p-2)_50%,var(--background-surface)_100%)] dark:after:opacity-25">
-      <div className="absolute top-0 right-0 -z-10 h-[42vh] w-[42vw] min-w-[260px] bg-[radial-gradient(circle,var(--color-p-3)_0%,transparent_62%)] opacity-55 blur-3xl dark:opacity-35" />
-
-      <section className="flex w-full max-w-[760px] flex-col items-center gap-9 text-center">
-        <div>
-          <Logo width={318} height={86} />
-        </div>
-
-        <div className="flex flex-col items-center gap-4">
-          <h1 className="text-title-3 text-main-text">GSM 통합 관리 시스템</h1>
-          <p className="text-text-3 text-sub-1 max-w-[430px]">
-            동아리, 기숙사, 홈베이스 기능을 한 곳에서 사용할 수 있어요.
+    <main className="bg-background flex min-h-screen items-center justify-center overflow-hidden px-5 py-10">
+      <section className="bg-background-surface flex h-fit w-fit flex-col items-center gap-6 rounded-2xl px-15 py-15">
+        <div className="flex flex-col items-center gap-2">
+          <Logo />
+          <p className="text-text-3 text-sub-1">
+            하나의 플랫폼, 학교 통합 관리 서비스
           </p>
         </div>
 
-        <div className="flex min-h-[80px] w-full max-w-[330px] flex-col gap-3">
+        <div className="flex w-full max-w-[330px] flex-col items-center gap-3">
           <DataGsmLoginButton
             className="w-full"
             disabled={isLoggingIn}

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -36,9 +36,7 @@ export default function Signin() {
         </div>
 
         <div className="flex flex-col items-center gap-4">
-          <h1 className="text-title-3 text-main-text">
-            GSM 통합 관리 시스템
-          </h1>
+          <h1 className="text-title-3 text-main-text">GSM 통합 관리 시스템</h1>
           <p className="text-text-3 text-sub-1 max-w-[430px]">
             동아리, 기숙사, 홈베이스 기능을 한 곳에서 사용할 수 있어요.
           </p>

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -27,24 +27,47 @@ export default function Signin() {
   };
 
   return (
-    <div className="bg-background flex min-h-screen items-center justify-center overflow-hidden px-5 py-10">
-      <div className="bg-background-surface flex min-h-[430px] w-full max-w-[480px] flex-col items-center justify-center gap-10 rounded-2xl px-8 py-12 shadow-[0_18px_60px_rgba(0,0,0,0.08)] dark:shadow-none">
-        <div className="flex flex-col items-center gap-8">
-          <Logo width={265} height={72} />
-          <div className="flex flex-col items-center gap-3 text-center">
-            <h1 className="text-title-1 text-main-text">로그인</h1>
-            <p className="text-text-3 text-sub-1">GSM 통합 관리 시스템</p>
+    <main className="bg-background flex min-h-screen items-center justify-center overflow-hidden px-5 py-10">
+      <section className="bg-background-surface grid w-full max-w-[960px] overflow-hidden rounded-2xl shadow-[0_18px_60px_rgba(0,0,0,0.08)] md:grid-cols-[1.08fr_0.92fr] dark:shadow-none">
+        <div className="bg-p-2 dark:bg-p-3 flex min-h-[280px] flex-col justify-between gap-8 px-8 py-8 md:min-h-[520px] md:px-10 md:py-10">
+          <Logo width={260} height={71} />
+          <div className="flex max-w-[360px] flex-col gap-4">
+            <p className="text-text-2 text-p-1">GSM 통합 관리 시스템</p>
+            <h1 className="text-main-text text-title-1">
+              학교생활과 기숙사 생활을
+              <br />한 곳에서 시작하세요
+            </h1>
+            <p className="text-sub-1 text-text-3">
+              동아리 개설부터 자습 관리, 안마의자 예약, 기상음악 신청과 AI
+              기능까지 플러딩에서 통합해 관리합니다.
+            </p>
           </div>
         </div>
-        <div className="flex min-h-[62px] flex-col items-center gap-3">
-          <DataGsmLoginButton disabled={isLoggingIn} onClick={handleLogin} />
-          {errorMessage && (
-            <p className="text-caption-2 text-negative w-[330px] text-center">
-              {errorMessage}
-            </p>
-          )}
+
+        <div className="flex min-h-[320px] items-center justify-center px-6 py-8 md:min-h-[520px] md:px-10">
+          <div className="flex w-full max-w-[330px] flex-col gap-8">
+            <div className="flex flex-col gap-3">
+              <h2 className="text-title-2 text-main-text">로그인</h2>
+              <p className="text-text-3 text-sub-1">
+                DataGSM 계정으로 안전하게 접속합니다.
+              </p>
+            </div>
+
+            <div className="flex min-h-[78px] flex-col gap-3">
+              <DataGsmLoginButton
+                className="w-full"
+                disabled={isLoggingIn}
+                onClick={handleLogin}
+              />
+              {errorMessage && (
+                <p className="text-caption-2 text-negative text-center">
+                  {errorMessage}
+                </p>
+              )}
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
+      </section>
+    </main>
   );
 }

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -27,45 +27,34 @@ export default function Signin() {
   };
 
   return (
-    <main className="bg-background flex min-h-screen items-center justify-center overflow-hidden px-5 py-10">
-      <section className="bg-background-surface grid w-full max-w-[960px] overflow-hidden rounded-2xl shadow-[0_18px_60px_rgba(0,0,0,0.08)] md:grid-cols-[1.08fr_0.92fr] dark:shadow-none">
-        <div className="bg-p-2 dark:bg-p-3 flex min-h-[280px] flex-col justify-between gap-8 px-8 py-8 md:min-h-[520px] md:px-10 md:py-10">
-          <Logo width={260} height={71} />
-          <div className="flex max-w-[360px] flex-col gap-4">
-            <p className="text-text-2 text-p-1">GSM 통합 관리 시스템</p>
-            <h1 className="text-main-text text-title-1">
-              학교생활과 기숙사 생활을
-              <br />한 곳에서 시작하세요
-            </h1>
-            <p className="text-sub-1 text-text-3">
-              동아리 개설부터 자습 관리, 안마의자 예약, 기상음악 신청과 AI
-              기능까지 플러딩에서 통합해 관리합니다.
-            </p>
-          </div>
+    <main className="bg-background relative isolate flex min-h-screen items-center justify-center overflow-hidden px-5 py-12 before:absolute before:inset-0 before:-z-20 before:bg-[linear-gradient(135deg,var(--background)_0%,var(--color-p-2)_52%,var(--background-surface)_100%)] after:absolute after:inset-0 after:-z-10 after:bg-[radial-gradient(circle_at_20%_20%,var(--color-p-3)_0_1px,transparent_1px),radial-gradient(circle_at_78%_72%,var(--color-sub-3)_0_1px,transparent_1px)] after:bg-[length:34px_34px,48px_48px] after:opacity-45 dark:before:bg-[linear-gradient(135deg,var(--background)_0%,var(--color-p-2)_50%,var(--background-surface)_100%)] dark:after:opacity-25">
+      <div className="absolute top-0 right-0 -z-10 h-[42vh] w-[42vw] min-w-[260px] bg-[radial-gradient(circle,var(--color-p-3)_0%,transparent_62%)] opacity-55 blur-3xl dark:opacity-35" />
+
+      <section className="flex w-full max-w-[760px] flex-col items-center gap-9 text-center">
+        <div>
+          <Logo width={318} height={86} />
         </div>
 
-        <div className="flex min-h-[320px] items-center justify-center px-6 py-8 md:min-h-[520px] md:px-10">
-          <div className="flex w-full max-w-[330px] flex-col gap-8">
-            <div className="flex flex-col gap-3">
-              <h2 className="text-title-2 text-main-text">로그인</h2>
-              <p className="text-text-3 text-sub-1">
-                DataGSM 계정으로 안전하게 접속합니다.
-              </p>
-            </div>
+        <div className="flex flex-col items-center gap-4">
+          <h1 className="text-title-3 text-main-text">
+            GSM 통합 관리 시스템
+          </h1>
+          <p className="text-text-3 text-sub-1 max-w-[430px]">
+            동아리, 기숙사, 홈베이스 기능을 한 곳에서 사용할 수 있어요.
+          </p>
+        </div>
 
-            <div className="flex min-h-[78px] flex-col gap-3">
-              <DataGsmLoginButton
-                className="w-full"
-                disabled={isLoggingIn}
-                onClick={handleLogin}
-              />
-              {errorMessage && (
-                <p className="text-caption-2 text-negative text-center">
-                  {errorMessage}
-                </p>
-              )}
-            </div>
-          </div>
+        <div className="flex min-h-[80px] w-full max-w-[330px] flex-col gap-3">
+          <DataGsmLoginButton
+            className="w-full"
+            disabled={isLoggingIn}
+            onClick={handleLogin}
+          />
+          {errorMessage && (
+            <p className="text-caption-2 text-negative text-center">
+              {errorMessage}
+            </p>
+          )}
         </div>
       </section>
     </main>

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -17,6 +17,14 @@ const authPathsWithoutRefresh = [
 
 let refreshPromise: Promise<string> | null = null;
 
+function redirectToSignin() {
+  const authPages = ["/signin", "/callback"];
+
+  if (!authPages.includes(window.location.pathname)) {
+    window.location.href = "/signin";
+  }
+}
+
 instance.interceptors.request.use((config) => {
   if (config.url?.startsWith("/api/")) {
     config.baseURL = undefined;
@@ -47,15 +55,19 @@ instance.interceptors.response.use(
 
       try {
         if (!refreshPromise) {
-          refreshPromise = axios.post("/api/auth/refresh").then(({ data }) => {
-            const token = data.data?.accessToken;
-            if (!token) {
-              throw new Error("Access token is missing");
-            }
-            sessionStorage.setItem("access_token", token);
-            refreshPromise = null;
-            return token;
-          });
+          refreshPromise = axios
+            .post("/api/auth/refresh")
+            .then(({ data }) => {
+              const token = data.data?.accessToken;
+              if (!token) {
+                throw new Error("Access token is missing");
+              }
+              sessionStorage.setItem("access_token", token);
+              return token;
+            })
+            .finally(() => {
+              refreshPromise = null;
+            });
         }
 
         const accessToken = await refreshPromise;
@@ -63,7 +75,7 @@ instance.interceptors.response.use(
         return instance(config);
       } catch (refreshError) {
         sessionStorage.removeItem("access_token");
-        window.location.href = "/signin";
+        redirectToSignin();
         return Promise.reject(refreshError);
       }
     }

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -21,7 +21,7 @@ function redirectToSignin() {
   const authPages = ["/signin", "/callback"];
 
   if (!authPages.includes(window.location.pathname)) {
-    window.location.href = "/signin";
+    window.location.replace("/signin");
   }
 }
 

--- a/src/shared/asset/svg/DBlack.tsx
+++ b/src/shared/asset/svg/DBlack.tsx
@@ -1,0 +1,25 @@
+export default function DBlack() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <rect x="0" y="0" width="10" height="2" fill="black" />
+      <rect x="0" y="2" width="4" height="2" fill="black" />
+      <rect x="8" y="2" width="4" height="2" fill="black" />
+      <rect x="0" y="4" width="4" height="2" fill="black" />
+      <rect x="10" y="4" width="4" height="2" fill="black" />
+      <rect x="0" y="6" width="4" height="2" fill="black" />
+      <rect x="10" y="6" width="4" height="2" fill="black" />
+      <rect x="0" y="8" width="4" height="2" fill="black" />
+      <rect x="10" y="8" width="4" height="2" fill="black" />
+      <rect x="0" y="10" width="4" height="2" fill="black" />
+      <rect x="8" y="10" width="4" height="2" fill="black" />
+      <rect x="0" y="12" width="10" height="2" fill="black" />
+    </svg>
+  );
+}

--- a/src/shared/asset/svg/DWhite.tsx
+++ b/src/shared/asset/svg/DWhite.tsx
@@ -1,0 +1,25 @@
+export default function DWhite() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <rect x="0" y="0" width="10" height="2" fill="white" />
+      <rect x="0" y="2" width="4" height="2" fill="white" />
+      <rect x="8" y="2" width="4" height="2" fill="white" />
+      <rect x="0" y="4" width="4" height="2" fill="white" />
+      <rect x="10" y="4" width="4" height="2" fill="white" />
+      <rect x="0" y="6" width="4" height="2" fill="white" />
+      <rect x="10" y="6" width="4" height="2" fill="white" />
+      <rect x="0" y="8" width="4" height="2" fill="white" />
+      <rect x="10" y="8" width="4" height="2" fill="white" />
+      <rect x="0" y="10" width="4" height="2" fill="white" />
+      <rect x="8" y="10" width="4" height="2" fill="white" />
+      <rect x="0" y="12" width="10" height="2" fill="white" />
+    </svg>
+  );
+}

--- a/src/shared/asset/svg/Logo.tsx
+++ b/src/shared/asset/svg/Logo.tsx
@@ -1,12 +1,20 @@
 interface LogoProps {
   iconOnly?: boolean;
+  width?: number;
+  height?: number;
 }
 
-export default function Logo({ iconOnly = false }: LogoProps) {
+export default function Logo({
+  iconOnly = false,
+  width,
+  height = 52,
+}: LogoProps) {
+  const defaultWidth = iconOnly ? 52 : 191;
+
   return (
     <svg
-      width={iconOnly ? "52" : "191"}
-      height="52"
+      width={width ?? defaultWidth}
+      height={height}
       viewBox={iconOnly ? "128 0 64 52" : "0 0 191 52"}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/shared/ui/Button/DataGsmLoginButton.tsx
+++ b/src/shared/ui/Button/DataGsmLoginButton.tsx
@@ -2,21 +2,23 @@ import DBlack from "@/shared/asset/svg/DBlack";
 import DWhite from "@/shared/asset/svg/DWhite";
 
 interface DataGsmLoginButtonProps {
+  className?: string;
   disabled?: boolean;
   onClick?: () => void;
 }
 
 const buttonStyles =
-  "inline-flex h-10 items-center gap-4 rounded-lg bg-black px-3 font-[Pretendard,sans-serif] text-[14px] font-medium text-white transition-all duration-200 ease-in-out cursor-pointer hover:bg-[#222222] disabled:cursor-default disabled:opacity-70 dark:bg-white dark:text-black dark:hover:bg-[#efefef]";
+  "inline-flex h-11 items-center justify-center gap-4 rounded-lg bg-black px-4 font-[Pretendard,sans-serif] text-[14px] font-medium whitespace-nowrap text-white transition-all duration-200 ease-in-out cursor-pointer hover:bg-[#222222] disabled:cursor-default disabled:opacity-70 dark:bg-white dark:text-black dark:hover:bg-[#efefef]";
 
 export function DataGsmLoginButton({
+  className,
   disabled = false,
   onClick,
 }: DataGsmLoginButtonProps) {
   return (
     <button
       type="button"
-      className={buttonStyles}
+      className={`${buttonStyles} ${className ?? ""}`}
       disabled={disabled}
       onClick={onClick}
     >

--- a/src/shared/ui/Button/DataGsmLoginButton.tsx
+++ b/src/shared/ui/Button/DataGsmLoginButton.tsx
@@ -1,0 +1,32 @@
+import DBlack from "@/shared/asset/svg/DBlack";
+import DWhite from "@/shared/asset/svg/DWhite";
+
+interface DataGsmLoginButtonProps {
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+const buttonStyles =
+  "inline-flex h-10 items-center gap-4 rounded-lg bg-black px-3 font-[Pretendard,sans-serif] text-[14px] font-medium text-white transition-all duration-200 ease-in-out cursor-pointer hover:bg-[#222222] disabled:cursor-default disabled:opacity-70 dark:bg-white dark:text-black dark:hover:bg-[#efefef]";
+
+export function DataGsmLoginButton({
+  disabled = false,
+  onClick,
+}: DataGsmLoginButtonProps) {
+  return (
+    <button
+      type="button"
+      className={buttonStyles}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <span className="block dark:hidden">
+        <DWhite />
+      </span>
+      <span className="hidden dark:block">
+        <DBlack />
+      </span>
+      DataGSM으로 로그인
+    </button>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#103

## 📝작업 내용

- DataGSM 디자인 시스템에 맞춘 로그인 버튼을 추가하고 로그인 페이지 UI를 개선했습니다.
- 로그인 callback 로딩/에러 화면의 반응형 레이아웃과 다크모드 표시를 정리했습니다.
- access token 재발급 실패 시 refresh token 쿠키를 제거하도록 인증 API 처리를 보완했습니다.
- access token 갱신 요청이 중복 실행되지 않도록 refresh promise 정리 로직을 개선했습니다.
- 인증 페이지(`/signin`, `/callback`)에서는 중복 로그인 리다이렉트가 발생하지 않도록 처리했습니다.

### 로그인 페이지

#### 원본

<img width="3420" height="2146" alt="2026-05-13_07-47-31" src="https://github.com/user-attachments/assets/9d106b23-460d-4107-8290-8284806ffd94" />

#### 선택 디자인

<img width="2560" height="1600" alt="2026-05-13_09-16-41" src="https://github.com/user-attachments/assets/8c865e00-46a1-4661-bb7a-3d10a46935e2" />

#### 시안 1

<img width="3420" height="2158" alt="image" src="https://github.com/user-attachments/assets/edf202e1-e156-406f-a45f-c0a1a490b1ed" />

#### 시안 2

<img width="3420" height="2146" alt="image" src="https://github.com/user-attachments/assets/d83e2d71-8833-4f78-9cdb-6ca90dbc9980" />

#### 시안 3

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/1c6c8230-10f7-42e8-b413-cc63eceddffa" />

### 로딩 페이지

<img width="3420" height="2146" alt="image" src="https://github.com/user-attachments/assets/5c198293-9766-4e63-b9e5-698f3095aaeb" />


<img width="1728" height="2154" alt="image" src="https://github.com/user-attachments/assets/c23744ef-3e97-4133-8deb-095f6ebedb7b" />
