### PR TITLE
fix: 동아리 개설 상태 필터 및 신청 제한 수정

### DIFF
--- a/src/entities/dormitory/api/dormitoryQueries.ts
+++ b/src/entities/dormitory/api/dormitoryQueries.ts
@@ -26,12 +26,16 @@ export const dormitoryQueries = {
     queryOptions({
       queryKey: ["dormitory", "massage"],
       queryFn: getMassageApplicants,
+      refetchOnMount: "always",
+      refetchOnWindowFocus: "always",
     }),
 
   study: () =>
     queryOptions({
       queryKey: ["dormitory", "study"],
       queryFn: getSelfStudyApplicants,
+      refetchOnMount: "always",
+      refetchOnWindowFocus: "always",
     }),
 
   myPenalties: () =>

--- a/src/features/club/lib/filterClubs.ts
+++ b/src/features/club/lib/filterClubs.ts
@@ -1,21 +1,27 @@
-import type { Club } from "@/entities/club/model/club";
+import type { Club, ClubType } from "@/entities/club/model/club";
+
+export type ClubTypeFilter = ClubType | "ALL";
 
 interface FilterClubsParams {
   clubs: Club[];
   searchValue: string;
+  type: ClubTypeFilter;
 }
 
-export function filterClubs({ clubs, searchValue }: FilterClubsParams): Club[] {
+export function filterClubs({
+  clubs,
+  searchValue,
+  type,
+}: FilterClubsParams): Club[] {
   const normalizedSearchValue = searchValue.trim().toLowerCase();
 
-  if (!normalizedSearchValue) {
-    return clubs;
-  }
-
   return clubs.filter((club) => {
-    return (
+    const matchesType = type === "ALL" || club.type === type;
+    const matchesSearch =
+      !normalizedSearchValue ||
       club.name.toLowerCase().includes(normalizedSearchValue) ||
-      club.leader?.toLowerCase().includes(normalizedSearchValue)
-    );
+      club.leader?.toLowerCase().includes(normalizedSearchValue);
+
+    return matchesType && matchesSearch;
   });
 }

--- a/src/features/club/ui/ClubApplicationListSection.tsx
+++ b/src/features/club/ui/ClubApplicationListSection.tsx
@@ -6,6 +6,7 @@ import Club from "@/shared/asset/svg/Club";
 import { clubQueries } from "@/entities/club/api/clubQueries";
 import { userQueries } from "@/entities/user/api/userQueries";
 import { TextButton } from "@/shared/ui/Button/TextButton";
+import { formatDateParam } from "@/shared/lib/date";
 import {
   ClientQueryBoundary,
   type QueryErrorFallbackProps,
@@ -18,28 +19,17 @@ interface ClubApplicationListSectionProps {
   id: number;
 }
 
-const submittedAtPattern =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})?$/;
-
 function formatSubmittedAt(value: string) {
-  if (!submittedAtPattern.test(value)) {
-    return value;
-  }
-
-  const hasTimeZone = /(?:Z|[+-]\d{2}:\d{2})$/.test(value);
-  const date = new Date(hasTimeZone ? value : `${value}+09:00`);
+  const date = new Date(value);
 
   if (Number.isNaN(date.getTime())) {
     return value;
   }
 
-  return new Intl.DateTimeFormat("ko-KR", {
-    month: "numeric",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    timeZone: "Asia/Seoul",
-  }).format(date);
+  return formatDateParam(date, { hour: true, minute: true }).replaceAll(
+    "-",
+    ".",
+  );
 }
 
 function getErrorMessage(error: unknown) {

--- a/src/features/club/ui/ClubDetailSection.tsx
+++ b/src/features/club/ui/ClubDetailSection.tsx
@@ -12,6 +12,7 @@ import {
   usePatchClubApproval,
 } from "@/entities/club/api/clubQueries";
 import { userQueries } from "@/entities/user/api/userQueries";
+import { isManagementRole } from "@/entities/user/lib/userRole";
 import type { ClubMember } from "@/entities/club/model/club";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import {
@@ -101,15 +102,21 @@ const ClubDetailSection = ({
 
   const { data: detail } = useSuspenseQuery(clubQueries.detail(id));
   const { data: user } = useSuspenseQuery(userQueries.me());
-  const { data: openingStatus } = useSuspenseQuery(clubQueries.openingStatus());
+  const canCheckOpeningStatus = isManagementRole(user.role);
+  const { data: openingStatus } = useQuery({
+    ...clubQueries.openingStatus(),
+    enabled: canCheckOpeningStatus,
+    retry: false,
+  });
 
   const isLeader = detail.isLeader;
-  const isManager = user.role === "ADMIN" || user.role === "STUDENT_COUNCIL";
+  const isClubManager =
+    user.role === "ADMIN" || user.role === "STUDENT_COUNCIL";
   const hasClubApplication = user.hasClubApplication ?? false;
   const canDeleteClub =
-    (isLeader || user.role === "ADMIN") && openingStatus.isOpened;
+    (isLeader || user.role === "ADMIN") && openingStatus?.isOpened === true;
   const canCreateForm = detail.club.type === "MAJOR_CLUB" && isLeader;
-  const canViewApplications = isLeader || isManager;
+  const canViewApplications = isLeader || isClubManager;
   const formQuery = clubQueries.form(id);
   const { data: form, error: formError } = useQuery({
     ...formQuery,
@@ -191,7 +198,7 @@ const ClubDetailSection = ({
                   : undefined
               }
               onApplyClick={
-                isPending || isManager || hasClubApplication
+                isPending || isClubManager || hasClubApplication
                   ? undefined
                   : handleApplyClick
               }
@@ -214,7 +221,7 @@ const ClubDetailSection = ({
               memberSearchResults={memberSearchResults}
               onMemberSearchChange={setMemberSearch}
             />
-            {isManager && isPending && (
+            {isClubManager && isPending && (
               <div className="flex justify-end">
                 <div className="flex w-[240px] gap-2">
                   <TextButton

--- a/src/features/club/ui/ClubRegistrationSection.tsx
+++ b/src/features/club/ui/ClubRegistrationSection.tsx
@@ -162,7 +162,7 @@ export default function ClubRegistrationSection({
                 className="flex-1"
                 onClick={() => handleChange("type", "MAJOR_CLUB")}
               >
-                정규
+                전공
               </TextButton>
               <TextButton
                 variant={type === "AUTONOMOUS_CLUB" ? "filled" : "outlined"}

--- a/src/features/club/ui/ClubSearch.tsx
+++ b/src/features/club/ui/ClubSearch.tsx
@@ -1,17 +1,22 @@
 import Search from "@/shared/asset/svg/Search";
 import TextField from "@/shared/ui/textField";
 import { TextButton } from "@/shared/ui/Button/TextButton";
+import type { ClubTypeFilter } from "../lib/filterClubs";
 
 interface ClubSearchProps {
   query: string;
   setQuery: (value: string) => void;
   onSearch: () => void;
+  selectedType: ClubTypeFilter;
+  onTypeChange: (type: ClubTypeFilter) => void;
 }
 
 export default function ClubSearch({
   query,
   setQuery,
   onSearch,
+  selectedType,
+  onTypeChange,
 }: ClubSearchProps) {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") onSearch();
@@ -28,6 +33,36 @@ export default function ClubSearch({
           rightIcon={<Search />}
           className="w-full"
         />
+      </div>
+
+      <div className="flex w-full flex-col gap-1">
+        <span className="text-text-3">동아리 유형</span>
+        <div className="flex w-full gap-1">
+          <TextButton
+            variant={selectedType === "MAJOR_CLUB" ? "filled" : "outlined"}
+            size="fit"
+            className="flex-1"
+            onClick={() =>
+              onTypeChange(selectedType === "MAJOR_CLUB" ? "ALL" : "MAJOR_CLUB")
+            }
+          >
+            전공
+          </TextButton>
+          <TextButton
+            variant={
+              selectedType === "AUTONOMOUS_CLUB" ? "filled" : "outlined"
+            }
+            size="fit"
+            className="flex-1"
+            onClick={() =>
+              onTypeChange(
+                selectedType === "AUTONOMOUS_CLUB" ? "ALL" : "AUTONOMOUS_CLUB",
+              )
+            }
+          >
+            자율
+          </TextButton>
+        </div>
       </div>
 
       <div className="w-full">

--- a/src/features/club/ui/ClubSearch.tsx
+++ b/src/features/club/ui/ClubSearch.tsx
@@ -49,9 +49,7 @@ export default function ClubSearch({
             전공
           </TextButton>
           <TextButton
-            variant={
-              selectedType === "AUTONOMOUS_CLUB" ? "filled" : "outlined"
-            }
+            variant={selectedType === "AUTONOMOUS_CLUB" ? "filled" : "outlined"}
             size="fit"
             className="flex-1"
             onClick={() =>

--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -23,14 +23,19 @@ export function MassageChairSection() {
     applicants.some((student) => student.studentNumber === user.studentNumber);
   const isMassageActionPending =
     applyMutation.isPending || cancelMutation.isPending;
-  const isMassageActionDisabled =
+  const isMassageApplyDisabled =
     isUserLoading ||
     isMassageLoading ||
     isMassageActionPending ||
-    !isApplicationOpen;
+    isApplicationOpen;
+  const isMassageCancelDisabled =
+    isUserLoading || isMassageLoading || isMassageActionPending;
+  const isMassageActionDisabled = hasAppliedMassage
+    ? isMassageCancelDisabled
+    : isMassageApplyDisabled;
 
   const handleApplyMassage = () => {
-    if (isMassageActionDisabled || hasAppliedMassage) {
+    if (isMassageApplyDisabled || hasAppliedMassage) {
       return;
     }
 
@@ -38,7 +43,7 @@ export function MassageChairSection() {
   };
 
   const handleCancelMassage = () => {
-    if (isMassageActionDisabled || !hasAppliedMassage) {
+    if (isMassageCancelDisabled || !hasAppliedMassage) {
       return;
     }
 
@@ -82,10 +87,10 @@ export function MassageChairSection() {
           >
             {isUserLoading || isMassageLoading
               ? "확인 중"
-              : !isApplicationOpen
-                ? "신청 불가"
-                : hasAppliedMassage
-                  ? "취소하기"
+              : hasAppliedMassage
+                ? "취소하기"
+                : isApplicationOpen
+                  ? "신청 불가"
                   : "신청하기"}
           </TextButton>
           <p className="text-sub-2 text-caption-2">

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -37,12 +37,17 @@ export function SelfStudySection() {
     students.some((student) => student.userId === user.id);
   const isStudyActionPending =
     applyMutation.isPending || cancelMutation.isPending;
-  const isStudyActionDisabled =
+  const isStudyApplyDisabled =
     isUserLoading ||
     isStudyLoading ||
     isStudyBanned ||
     isStudyActionPending ||
-    !isApplicationOpen;
+    isApplicationOpen;
+  const isStudyCancelDisabled =
+    isUserLoading || isStudyLoading || isStudyBanned || isStudyActionPending;
+  const isStudyActionDisabled = hasAppliedStudy
+    ? isStudyCancelDisabled
+    : isStudyApplyDisabled;
   const canManageStudy = isManagementRole(user?.role);
   const { checkedStudentIds, markChecked } = useStudyAttendanceSubscription(
     user?.role,
@@ -64,7 +69,7 @@ export function SelfStudySection() {
       payload: selectedGender === gender ? null : gender,
     });
   const handleApplyStudy = () => {
-    if (isStudyActionDisabled || hasAppliedStudy) {
+    if (isStudyApplyDisabled || hasAppliedStudy) {
       return;
     }
 
@@ -72,7 +77,7 @@ export function SelfStudySection() {
   };
 
   const handleCancelStudy = () => {
-    if (isStudyActionDisabled || !hasAppliedStudy) {
+    if (isStudyCancelDisabled || !hasAppliedStudy) {
       return;
     }
 
@@ -218,10 +223,10 @@ export function SelfStudySection() {
               ? "자습 금지를 당했어요!"
               : isUserLoading || isStudyLoading
                 ? "확인 중"
-                : !isApplicationOpen
-                  ? "신청 불가"
-                  : hasAppliedStudy
-                    ? "취소하기"
+                : hasAppliedStudy
+                  ? "취소하기"
+                  : isApplicationOpen
+                    ? "신청 불가"
                     : "신청하기"}
           </TextButton>
 

--- a/src/shared/api/queryClient.ts
+++ b/src/shared/api/queryClient.ts
@@ -5,7 +5,7 @@ const MINUTE = 60 * 1000;
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30 * MINUTE,
+      staleTime: MINUTE,
       gcTime: 60 * MINUTE,
       retry: 1,
       refetchOnWindowFocus: false,

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -1,7 +1,25 @@
-export function formatDateParam(date: Date): string {
+interface FormatDateParamOptions {
+  hour?: boolean;
+  minute?: boolean;
+}
+
+export function formatDateParam(
+  date: Date,
+  options: FormatDateParamOptions = {},
+): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
+  const formattedDate = `${year}-${month}-${day}`;
 
-  return `${year}-${month}-${day}`;
+  const timeParts = [
+    options.hour && String(date.getHours()).padStart(2, "0"),
+    options.minute && String(date.getMinutes()).padStart(2, "0"),
+  ].filter(Boolean);
+
+  if (timeParts.length === 0) {
+    return formattedDate;
+  }
+
+  return `${formattedDate} ${timeParts.join(":")}`;
 }

--- a/src/widgets/club/ui/ClubHomeSection.tsx
+++ b/src/widgets/club/ui/ClubHomeSection.tsx
@@ -21,7 +21,11 @@ import ClubSearch from "@/features/club/ui/ClubSearch";
 import ClubRegistrationSection from "@/features/club/ui/ClubRegistrationSection";
 import { ClubOpeningRequestSection } from "@/features/club/ui/ClubOpeningRequestSection";
 import ClubExportButton from "@/features/club/ui/ClubExportButton";
-import { filterClubs } from "@/features/club/lib/filterClubs";
+import {
+  filterClubs,
+  type ClubTypeFilter,
+} from "@/features/club/lib/filterClubs";
+import { isManagementRole } from "@/entities/user/lib/userRole";
 
 function ClubCardSkeleton() {
   return (
@@ -106,21 +110,29 @@ function ClubHomeSection() {
   const [viewMode, setViewMode] = useState<"form" | "list">("list");
   const [query, setQuery] = useState("");
   const [searchValue, setSearchValue] = useState("");
+  const [selectedType, setSelectedType] = useState<ClubTypeFilter>("ALL");
 
   const { data } = useSuspenseQuery(clubQueries.list());
   const { data: user } = useSuspenseQuery(userQueries.me());
-  const { data: openingStatus } = useSuspenseQuery(clubQueries.openingStatus());
-  const isManager = user.role === "ADMIN" || user.role === "STUDENT_COUNCIL";
+  const canCheckOpeningStatus = isManagementRole(user.role);
+  const { data: openingStatus } = useQuery({
+    ...clubQueries.openingStatus(),
+    enabled: canCheckOpeningStatus,
+    retry: false,
+  });
+  const isClubManager =
+    user.role === "ADMIN" || user.role === "STUDENT_COUNCIL";
   const isAdmin = user.role === "ADMIN";
   const { data: openingRequests, isLoading: isOpeningRequestsLoading } =
     useQuery({
       ...clubQueries.openingRequests(),
-      enabled: isManager && viewMode === "form",
+      enabled: isClubManager && viewMode === "form",
     });
 
   const filteredClubs = filterClubs({
     clubs: data.clubs,
     searchValue,
+    type: selectedType,
   });
   const sectionTitle = viewMode === "form" ? "개설 신청" : "동아리";
   const count =
@@ -139,7 +151,8 @@ function ClubHomeSection() {
   };
 
   const handleSearch = () => setSearchValue(query);
-  const canRegisterClub = openingStatus.isOpened;
+  const canRegisterClub =
+    canCheckOpeningStatus && openingStatus?.isOpened === true;
   const clubModeToggle = (
     <div className="flex w-full gap-1">
       <TextButton
@@ -196,7 +209,7 @@ function ClubHomeSection() {
                 onClubClick={(clubId) => router.push(`/club/${clubId}`)}
               />
             ) : (
-              isManager && <ClubOpeningRequestSection />
+              isClubManager && <ClubOpeningRequestSection />
             )}
           </div>
           <div className="order-1 flex flex-col items-center justify-center lg:order-2 lg:w-[330px] lg:shrink-0 lg:self-stretch">
@@ -213,6 +226,8 @@ function ClubHomeSection() {
                   query={query}
                   setQuery={handleQueryChange}
                   onSearch={handleSearch}
+                  selectedType={selectedType}
+                  onTypeChange={setSelectedType}
                 />
               )}
               {isAdmin && <ClubExportButton />}

--- a/src/widgets/main/ui/MassageApplyCard.tsx
+++ b/src/widgets/main/ui/MassageApplyCard.tsx
@@ -24,14 +24,19 @@ export default function MassageApplyCard() {
     applicants.some((student) => student.studentNumber === user.studentNumber);
   const isMassageActionPending =
     applyMutation.isPending || cancelMutation.isPending;
-  const isMassageActionDisabled =
+  const isMassageApplyDisabled =
     isUserLoading ||
     isMassageLoading ||
     isMassageActionPending ||
-    !isApplicationOpen;
+    isApplicationOpen;
+  const isMassageCancelDisabled =
+    isUserLoading || isMassageLoading || isMassageActionPending;
+  const isMassageActionDisabled = hasAppliedMassage
+    ? isMassageCancelDisabled
+    : isMassageApplyDisabled;
 
   const handleApplyMassage = () => {
-    if (isMassageActionDisabled || hasAppliedMassage) {
+    if (isMassageApplyDisabled || hasAppliedMassage) {
       return;
     }
 
@@ -39,7 +44,7 @@ export default function MassageApplyCard() {
   };
 
   const handleCancelMassage = () => {
-    if (isMassageActionDisabled || !hasAppliedMassage) {
+    if (isMassageCancelDisabled || !hasAppliedMassage) {
       return;
     }
 
@@ -56,13 +61,13 @@ export default function MassageApplyCard() {
       buttonText={
         isUserLoading || isMassageLoading
           ? "확인 중"
-          : !isApplicationOpen
-            ? "신청 불가"
-            : hasAppliedMassage
-              ? "취소"
+          : hasAppliedMassage
+            ? "취소"
+            : isApplicationOpen
+              ? "신청 불가"
               : "신청"
       }
-      buttonSize={!isApplicationOpen ? "fit" : "small"}
+      buttonSize={!hasAppliedMassage && isApplicationOpen ? "fit" : "small"}
       detailHref="/dormitory"
       femaleNotice
       disabled={isMassageActionDisabled}

--- a/src/widgets/main/ui/StudyApplyCard.tsx
+++ b/src/widgets/main/ui/StudyApplyCard.tsx
@@ -25,15 +25,20 @@ export default function StudyApplyCard() {
     students.some((student) => student.userId === user.id);
   const isStudyActionPending =
     applyMutation.isPending || cancelMutation.isPending;
-  const isStudyActionDisabled =
+  const isStudyApplyDisabled =
     isUserLoading ||
     isStudyLoading ||
     isStudyBanned ||
     isStudyActionPending ||
-    !isApplicationOpen;
+    isApplicationOpen;
+  const isStudyCancelDisabled =
+    isUserLoading || isStudyLoading || isStudyBanned || isStudyActionPending;
+  const isStudyActionDisabled = hasAppliedStudy
+    ? isStudyCancelDisabled
+    : isStudyApplyDisabled;
 
   const handleApplyStudy = () => {
-    if (isStudyActionDisabled || hasAppliedStudy) {
+    if (isStudyApplyDisabled || hasAppliedStudy) {
       return;
     }
 
@@ -41,7 +46,7 @@ export default function StudyApplyCard() {
   };
 
   const handleCancelStudy = () => {
-    if (isStudyActionDisabled || !hasAppliedStudy) {
+    if (isStudyCancelDisabled || !hasAppliedStudy) {
       return;
     }
 
@@ -60,14 +65,18 @@ export default function StudyApplyCard() {
           ? "자습 금지를 당했어요!"
           : isUserLoading || isStudyLoading
             ? "확인 중"
-            : !isApplicationOpen
-              ? "신청 불가"
-              : hasAppliedStudy
-                ? "취소"
+            : hasAppliedStudy
+              ? "취소"
+              : isApplicationOpen
+                ? "신청 불가"
                 : "신청"
       }
       buttonVariant={isStudyBanned ? "negative" : "filled"}
-      buttonSize={isStudyBanned || !isApplicationOpen ? "fit" : "small"}
+      buttonSize={
+        isStudyBanned || (!hasAppliedStudy && isApplicationOpen)
+          ? "fit"
+          : "small"
+      }
       detailHref="/dormitory"
       disabled={isStudyActionDisabled}
       onApply={hasAppliedStudy ? handleCancelStudy : handleApplyStudy}


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 동아리 목록 검색에 전공/자율 유형 필터를 추가하고, 동아리 등록 문구를 `전공`으로 정리했습니다.
- 관리자 권한에서만 동아리 개설 상태를 조회하도록 변경해 일반 사용자 접근 시 불필요한 요청을 막았습니다.
- 자습/안마의자 신청 상태 판별을 이미 자습/안마의자를 신청 후 취소를 한 학생은 사용이 불가능하도록 하였습니다.
- 자습/안마의자 신청자 목록을 화면 진입 및 포커스 복귀 시 다시 가져오도록 조정하고 기본 staleTime을 1분으로 줄였습니다.
- 동아리 신청자 제출 시간을 공통 날짜 포맷 유틸 기반으로 표시하도록 변경했습니다.