### PR TITLE
change: 동아리 수정 모드 상태를 URL 쿼리 스트링으로 관리

### DIFF
--- a/src/entities/club/ui/ClubActionButtons.tsx
+++ b/src/entities/club/ui/ClubActionButtons.tsx
@@ -5,7 +5,6 @@ interface ClubActionButtonsProps {
   isEdit: boolean;
   canDelete: boolean;
   onSave: () => void;
-  onCancel: () => void;
   onDelete: () => void;
 }
 
@@ -13,7 +12,6 @@ export function ClubActionButtons({
   isEdit,
   canDelete,
   onSave,
-  onCancel,
   onDelete,
 }: ClubActionButtonsProps) {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -23,14 +21,6 @@ export function ClubActionButtons({
     return (
       <>
         <div className="flex gap-2">
-          <TextButton
-            size="fit"
-            variant="ghost"
-            className="min-w-[118px] flex-1"
-            onClick={onCancel}
-          >
-            돌아가기
-          </TextButton>
           {canDelete && (
             <TextButton
               size="fit"

--- a/src/entities/club/ui/ClubDetail.tsx
+++ b/src/entities/club/ui/ClubDetail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { ClubThumbnail } from "@/entities/club/ui/ClubThumbnail";
@@ -33,7 +33,6 @@ interface ClubDetailProps {
   onViewApplicationsClick?: () => void;
   onCreateFormClick?: () => void;
   onTransferClick?: (member: ClubMember) => void;
-  onEditClick?: () => void;
   memberSearchQuery?: string;
   memberSearchResults?: SearchUser[];
   onMemberSearchChange?: (query: string) => void;
@@ -49,7 +48,6 @@ export default function ClubDetail({
   onViewApplicationsClick,
   onCreateFormClick,
   onTransferClick,
-  onEditClick,
   memberSearchQuery = "",
   memberSearchResults = [],
   onMemberSearchChange,
@@ -57,10 +55,12 @@ export default function ClubDetail({
   canDelete = false,
 }: ClubDetailProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const { club, members, projects, isLeader } = detail;
 
-  const [isEdit, setIsEdit] = useState(false);
+  const isEdit = searchParams.has("edit");
   const [description, setDescription] = useState(club.description ?? "");
   const [previewUrl, setPreviewUrl] = useState(club.imageUrl ?? "");
   const [representativeImage, setRepresentativeImage] = useState<File | null>(
@@ -102,17 +102,16 @@ export default function ClubDetail({
     setRepresentativeImage(null);
     setPreviewUrl(club.imageUrl ?? "");
     setEditableMembers(members);
-    setIsEdit(true);
-    onEditClick?.();
+    router.replace(`${pathname}?edit`);
   };
 
   const handleCancel = () => {
-    setIsEdit(false);
     setDescription(club.description ?? "");
     setRepresentativeImage(null);
     setPreviewUrl(club.imageUrl ?? "");
     setEditableMembers(members);
     onMemberSearchChange?.("");
+    router.replace(pathname);
   };
 
   const handleMemberInvite = (user: SearchUser) => {
@@ -199,10 +198,10 @@ export default function ClubDetail({
     toast.promise(promise, {
       loading: "저장 중...",
       success: () => {
-        setIsEdit(false);
         setRepresentativeImage(null);
         setEditableMembers(members);
         onMemberSearchChange?.("");
+        router.replace(pathname);
         queryClient.invalidateQueries({ queryKey: ["club"] });
         queryClient.invalidateQueries({
           queryKey: ["club", "detail", club.id],
@@ -361,7 +360,6 @@ export default function ClubDetail({
             isEdit={isEdit}
             canDelete={canDelete}
             onSave={handleSave}
-            onCancel={handleCancel}
             onDelete={handleDelete}
           />
           {!isEdit && (

--- a/src/entities/club/ui/ClubDetail.tsx
+++ b/src/entities/club/ui/ClubDetail.tsx
@@ -105,15 +105,6 @@ export default function ClubDetail({
     router.replace(`${pathname}?edit`);
   };
 
-  const handleCancel = () => {
-    setDescription(club.description ?? "");
-    setRepresentativeImage(null);
-    setPreviewUrl(club.imageUrl ?? "");
-    setEditableMembers(members);
-    onMemberSearchChange?.("");
-    router.replace(pathname);
-  };
-
   const handleMemberInvite = (user: SearchUser) => {
     setEditableMembers((currentMembers) => {
       if (currentMembers.some((member) => member.id === user.id)) {

--- a/src/features/club/ui/ClubDetailSection.tsx
+++ b/src/features/club/ui/ClubDetailSection.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import axios, { HttpStatusCode } from "axios";
-import { notFound, useRouter } from "next/navigation";
+import { notFound, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import Club from "@/shared/asset/svg/Club";
 import ClubDetail from "@/entities/club/ui/ClubDetail";
@@ -93,6 +93,8 @@ const ClubDetailSection = ({
   }
 
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const isEditing = searchParams.has("edit");
   const autonomousApplyMutation = useApplyAutonomousClub(id);
   const transferMutation = useTransferClubLeader(id);
   const { mutate: patchApproval, isPending: isApprovalPending } =
@@ -214,12 +216,11 @@ const ClubDetailSection = ({
                   ? handleTransferClick
                   : undefined
               }
-              onEditClick={clubPermission.canEditClub ? () => {} : undefined}
               memberSearchQuery={memberSearch}
               memberSearchResults={memberSearchResults}
               onMemberSearchChange={setMemberSearch}
             />
-            {clubPermission.isManager && isPending && (
+            {clubPermission.isManager && isPending && !isEditing && (
               <div className="flex justify-end">
                 <div className="flex w-[240px] gap-2">
                   <TextButton


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 동아리 수정 모드 활성화 여부를 `useState` 대신 URL 쿼리 스트링(`?edit`)으로 관리
- 수정 모드 진입·취소·저장 시 `router.replace`로 URL 상태를 반영
- `ClubActionButtons`에서 돌아가기 버튼 제거 (URL 기반 상태 전환으로 불필요)
- `ClubDetailSection`에서 `isEditing`을 URL 쿼리 스트링 기반으로 판단하여 승인 대기 UI 조건에 반영

<img width="1301" height="921" alt="image" src="https://github.com/user-attachments/assets/4f5d3295-20f2-47a2-a2df-52619ead7ec2" />

<img width="1301" height="796" alt="image" src="https://github.com/user-attachments/assets/6e2fd9e8-1a7a-4a86-b89e-71f460582f2e" />