### PR TITLE
refactor: YouTube 메타데이터를 Music 모델에 내장

### DIFF
--- a/src/entities/music/model/music.ts
+++ b/src/entities/music/model/music.ts
@@ -4,6 +4,12 @@ export interface Music {
   appliedAt: string;
   likeCount: number;
   isLiked: boolean;
+  title?: string | null;
+  artist?: string | null;
+  duration?: string | null;
+  durationText?: string | null;
+  thumbnailUrl?: string | null;
+  videoUrl?: string | null;
 }
 
 export interface RecommendedMusic extends Music {

--- a/src/entities/music/ui/MusicListItem.tsx
+++ b/src/entities/music/ui/MusicListItem.tsx
@@ -1,5 +1,4 @@
 import type { Music } from "@/entities/music/model/music";
-import type { YoutubeVideoMetadata } from "@/entities/music/api/youtubeQueries";
 import { getYoutubeThumbnailUrl } from "@/entities/music/lib/youtube";
 import Heart from "@/shared/asset/svg/Heart";
 import Delete from "@/shared/asset/svg/Delete";
@@ -7,7 +6,6 @@ import Image from "next/image";
 
 interface MusicListItemProps {
   music: Music;
-  youtubeMetadata?: YoutubeVideoMetadata;
   onToggleLike?: () => void;
   isLikePending?: boolean;
   onDelete?: () => void;
@@ -20,15 +18,14 @@ function formatAppliedDate(appliedAt: string) {
 
 export function MusicListItem({
   music,
-  youtubeMetadata,
   onToggleLike,
   isLikePending = false,
   onDelete,
   isDeletePending = false,
 }: MusicListItemProps) {
   const thumbnailUrl =
-    youtubeMetadata?.thumbnailUrl ?? getYoutubeThumbnailUrl(music.musicUrl);
-  const title = youtubeMetadata?.title ?? music.musicUrl;
+    music.thumbnailUrl ?? getYoutubeThumbnailUrl(music.musicUrl);
+  const title = music.title ?? music.musicUrl;
 
   return (
     <div className="border-sub-3 flex items-center justify-between gap-4 border-b py-3 pr-6 last:border-b-0">
@@ -42,9 +39,9 @@ export function MusicListItem({
               className="object-cover"
             />
           )}
-          {youtubeMetadata?.durationText && (
+          {music.durationText && (
             <span className="text-caption-3 absolute right-1.5 bottom-1.5 rounded bg-black/70 px-1.5 py-0.5 text-white">
-              {youtubeMetadata.durationText}
+              {music.durationText}
             </span>
           )}
         </div>

--- a/src/features/wake-up-music/model/useWakeUpMusic.ts
+++ b/src/features/wake-up-music/model/useWakeUpMusic.ts
@@ -5,8 +5,6 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import axios, { HttpStatusCode } from "axios";
 import { toast } from "sonner";
 import type { Music } from "@/entities/music/model/music";
-import { extractYoutubeVideoId } from "@/entities/music/lib/youtube";
-import { youtubeQueries } from "@/entities/music/api/youtubeQueries";
 import {
   dormitoryQueries,
   dormitoryMutations,
@@ -22,13 +20,6 @@ export function useWakeUpMusic() {
   const musicQuery = dormitoryQueries.music(selectedDateString);
 
   const { data: songs = [] } = useQuery(musicQuery);
-
-  const youtubeVideoIds = songs
-    .map((music) => extractYoutubeVideoId(music.musicUrl))
-    .filter((id): id is string => Boolean(id));
-  const { data: youtubeVideos = {} } = useQuery(
-    youtubeQueries.videos(youtubeVideoIds),
-  );
 
   const applyMutation = useMutation({
     mutationFn: () => dormitoryMutations.applyMusic({ musicUrl: urlInput }),
@@ -133,7 +124,6 @@ export function useWakeUpMusic() {
     selectedDate,
     setSelectedDate,
     songs,
-    youtubeVideos,
     applyMutation,
     handleSubmitRecommendedMusic,
     likeMutation,

--- a/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
+++ b/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ReactNode, useState } from "react";
-import { extractYoutubeVideoId } from "@/entities/music/lib/youtube";
 import { MusicListItem } from "@/entities/music/ui/MusicListItem";
 import { Calendar } from "@/shared/ui/Calendar";
 import { TextButton } from "@/shared/ui/Button/TextButton";
@@ -25,7 +24,6 @@ export function WakeUpMusicSection({
     selectedDate,
     setSelectedDate,
     songs,
-    youtubeVideos,
     applyMutation,
     handleSubmitRecommendedMusic,
     likeMutation,
@@ -59,9 +57,6 @@ export function WakeUpMusicSection({
               <MusicListItem
                 key={music.id}
                 music={music}
-                youtubeMetadata={
-                  youtubeVideos[extractYoutubeVideoId(music.musicUrl) ?? ""]
-                }
                 isLikePending={
                   likeMutation.isPending &&
                   likeMutation.variables?.id === music.id


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- `Music` 인터페이스에 `title`, `artist`, `duration`, `durationText`, `thumbnailUrl`, `videoUrl` 필드 추가
- `MusicListItem` 컴포넌트에서 `youtubeMetadata` prop 제거 후 `music` 객체 필드 직접 참조
- `useWakeUpMusic`에서 YouTube 별도 API 쿼리(`youtubeQueries`, `youtubeVideos`) 제거
- `WakeUpMusicSection`에서 `youtubeVideos` 사용 및 `youtubeMetadata` prop 전달 제거

## 💬리뷰 요구사항

- 서버 응답에 YouTube 메타데이터 필드(`title`, `thumbnailUrl`, `durationText` 등)가 포함되는지 확인 필요