### PR TITLE
fix: 만료된 리프레시 토큰 쿠키 제거 문제 수정

### DIFF
--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -45,7 +45,13 @@ export async function POST(request: NextRequest) {
         status === HttpStatusCode.Unauthorized
       ) {
         const res = NextResponse.json(body, { status });
-        res.cookies.delete("refresh_token");
+        res.cookies.set("refresh_token", "", {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === "production",
+          sameSite: "lax",
+          path: "/",
+          maxAge: 0,
+        });
         return res;
       }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- `/api/auth/refresh`에서 리프레시 실패 시 쿠키 삭제가 동작하지 않던 문제 수정
- `cookies.delete()` 대신 발급 시 옵션(`httpOnly`, `secure`, `sameSite: "lax"`, `path: "/"`)과 동일한 속성으로 `maxAge: 0` 빈 쿠키를 덮어쓰도록 변경

## 💬리뷰 요구사항

- 프로덕션에서 리프레시 토큰이 401/400으로 만료되었을 때 `refresh_token` 쿠키가 실제로 제거되는지 확인 부탁드립니다.
