### PR TITLE
fix: 200 빈 응답 시 Sentry anomaly 미기록 버그 수정

### DIFF
--- a/src/shared/api/queryClient.ts
+++ b/src/shared/api/queryClient.ts
@@ -56,7 +56,7 @@ export const queryClient = new QueryClient({
       if (
         responseData.data !== null &&
         responseData.data !== undefined &&
-        responseData.data !== ""
+        (typeof responseData.data !== "string" || responseData.data.trim() !== "")
       )
         return;
 

--- a/src/shared/api/queryClient.ts
+++ b/src/shared/api/queryClient.ts
@@ -56,7 +56,8 @@ export const queryClient = new QueryClient({
       if (
         responseData.data !== null &&
         responseData.data !== undefined &&
-        (typeof responseData.data !== "string" || responseData.data.trim() !== "")
+        (typeof responseData.data !== "string" ||
+          responseData.data.trim() !== "")
       )
         return;
 

--- a/src/shared/api/queryClient.ts
+++ b/src/shared/api/queryClient.ts
@@ -53,7 +53,12 @@ export const queryClient = new QueryClient({
 
       if (responseData.status === HttpStatusCode.NoContent) return;
       if (responseData.status < 200 || responseData.status >= 300) return;
-      if (responseData.data !== null && responseData.data !== undefined) return;
+      if (
+        responseData.data !== null &&
+        responseData.data !== undefined &&
+        responseData.data !== ""
+      )
+        return;
 
       const context = getMutationContext(mutation.options.mutationKey);
       const parsedMeta = mutationMonitorMetaSchema.safeParse(


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- `MutationCache.onSuccess`에서 빈 응답 판별 시 `null`/`undefined`만 검사하던 조건에 빈 문자열(`""`) 추가
- Axios가 빈 body 응답을 `""`로 파싱할 때 `captureFeatureAnomaly`가 호출되지 않던 문제 수정 (기상 음악 신청 200 + 빈 응답 케이스)

### 200 + 빈응답

<img width="1548" height="602" alt="image" src="https://github.com/user-attachments/assets/efddfdc3-4086-4b10-8e94-4450073b5000" />

### 센트리에서 테스트를 제외한 로그는 보이지 않음

<img width="1624" height="1838" alt="image" src="https://github.com/user-attachments/assets/678bb4a8-7017-44b4-8ab0-4b8e2be86663" />

## 💬리뷰 요구사항

- Axios가 Content-Type 없이 빈 body를 반환하는 경우 `data: ""`로 파싱되는 점이 수정의 전제입니다. 서버 응답 형태에 따라 동작이 달라질 수 있으니 확인 부탁드립니다.