### PR TITLE
fix: release 태그가 적용되지 않는 문제

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,7 +16,5 @@
   - head-branch: ["^docs/.+"]
 
 "🪽 Type: Release":
-  - all:
-      base-branch: ["^main$"]
-      head-branch: ["^develop$"]
-  - head-branch: ["^release/.+"]
+  - base-branch: ["^main$"]
+  - head-branch: ["^develop/.+"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,5 +16,4 @@
   - head-branch: ["^docs/.+"]
 
 "🪽 Type: Release":
-  - base-branch: ["^main$"]
-  - head-branch: ["^develop/.+"]
+  - base-branch: "^main$"


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음


## 📝작업 내용

2026.0527.0000 형식의 릴리즈 PR 생성 시 릴리즈 라벨이 붙지 않는 문제를 해결하였습니다.

## 💬리뷰 요구사항(선택)

릴리즈 PR 생성 시 테스트가 필요합니다.
