### PR TITLE
feat: 기상음악 · 홈베이스 입력 검증 및 UI 피드백 개선

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,15 +8,15 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "**",
-      },
-      {
-        protocol: "https",
         hostname: "img.youtube.com",
       },
       {
         protocol: "https",
         hostname: "i.ytimg.com",
+      },
+      {
+        protocol: "https",
+        hostname: "*.r2.dev",
       },
     ],
   },

--- a/src/entities/music/ui/MusicListItem.tsx
+++ b/src/entities/music/ui/MusicListItem.tsx
@@ -30,7 +30,12 @@ export function MusicListItem({
   return (
     <div className="border-sub-3 flex items-center justify-between gap-4 border-b py-3 pr-6 last:border-b-0">
       <div className="flex min-w-0 flex-1 items-center gap-4">
-        <div className="bg-sub-4 relative h-17 w-30 shrink-0 overflow-hidden rounded-lg 2xl:h-22 2xl:w-39">
+        <a
+          href={music.videoUrl ?? music.musicUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="bg-sub-4 relative h-17 w-30 shrink-0 overflow-hidden rounded-lg 2xl:h-22 2xl:w-39"
+        >
           {thumbnailUrl && (
             <Image
               src={thumbnailUrl}
@@ -44,7 +49,7 @@ export function MusicListItem({
               {music.durationText}
             </span>
           )}
-        </div>
+        </a>
 
         <div className="flex min-w-0 flex-1 flex-col gap-3 2xl:flex-row 2xl:items-center 2xl:gap-6">
           <p className="text-text-1 text-main-text line-clamp-2 font-semibold break-all 2xl:min-w-0 2xl:flex-1">

--- a/src/features/homebase/lib/homebaseReservationSchema.ts
+++ b/src/features/homebase/lib/homebaseReservationSchema.ts
@@ -4,6 +4,6 @@ export const homebaseReservationDraftSchema = z.object({
   reservationDate: z.string().trim().min(1, "예약 날짜를 선택해주세요"),
   startPeriod: z.number().int().min(8).max(11),
   endPeriod: z.number().int().min(8).max(11),
-  reason: z.string().trim().min(1, "신청사유를 입력해주세요"),
   selectedTable: z.string().trim().min(1, "테이블을 선택해주세요"),
+  reason: z.string().trim().min(1, "신청사유를 입력해주세요"),
 });

--- a/src/features/homebase/model/useHomebaseReservationActions.ts
+++ b/src/features/homebase/model/useHomebaseReservationActions.ts
@@ -99,7 +99,10 @@ export function useHomebaseReservationActions({
     },
     onError: () => toast.error("취소에 실패했습니다. 다시 시도해주세요"),
   });
-  const canSubmit = homebasePermission.canReserve && !applyMutation.isPending;
+  const canSubmit =
+    homebasePermission.canReserve &&
+    !applyMutation.isPending &&
+    homebaseReservationDraftSchema.safeParse(reservationDraft).success;
 
   const handleSubmit = () => {
     if (!homebasePermission.canReserve || applyMutation.isPending) return;

--- a/src/features/homebase/model/useHomebaseReservationActions.ts
+++ b/src/features/homebase/model/useHomebaseReservationActions.ts
@@ -99,10 +99,7 @@ export function useHomebaseReservationActions({
     },
     onError: () => toast.error("취소에 실패했습니다. 다시 시도해주세요"),
   });
-  const canSubmit =
-    homebasePermission.canReserve &&
-    !applyMutation.isPending &&
-    homebaseReservationDraftSchema.safeParse(reservationDraft).success;
+  const canSubmit = homebasePermission.canReserve && !applyMutation.isPending;
 
   const handleSubmit = () => {
     if (!homebasePermission.canReserve || applyMutation.isPending) return;

--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -6,6 +6,7 @@ import { createApplicationActionState } from "@/entities/dormitory/lib/applicati
 import { ProfileCard } from "@/entities/user/ui/ProfileCard";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import { dormitoryQueries } from "@/entities/dormitory/api/dormitoryQueries";
+import { NoteText } from "@/shared/ui/NoteText";
 import { useApplyMassage } from "../model/useApplyMassage";
 import { useCancelMassage } from "../model/useCancelMassage";
 
@@ -91,12 +92,8 @@ export function MassageChairSection() {
                   ? "신청 불가"
                   : "신청하기"}
           </TextButton>
-          <p className="text-sub-2 text-caption-2">
-            ※ 안마의자 신청시간은 20:20 ~ 21:00 입니다
-          </p>
-          <p className="text-sub-2 text-caption-2">
-            ※ 여학생은 여기숙사 별도 신청 바랍니다
-          </p>
+          <NoteText>안마의자 신청시간은 20:20 ~ 21:00 입니다</NoteText>
+          <NoteText>여학생은 여기숙사 별도 신청 바랍니다</NoteText>
         </div>
       </div>
     </section>

--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -92,7 +92,7 @@ export function MassageChairSection() {
                   : "신청하기"}
           </TextButton>
           <p className="text-sub-2 text-caption-2">
-            안마의자 신청시간은 20:20 ~ 21:00 입니다
+            ※ 안마의자 신청시간은 20:20 ~ 21:00 입니다
           </p>
           <p className="text-sub-2 text-caption-2">
             ※ 여학생은 여기숙사 별도 신청 바랍니다

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -231,6 +231,11 @@ export function SelfStudySection() {
           <p className="text-sub-2 text-caption-2">
             ※ 자습 신청 시간은 20:00 ~ 21:00 입니다
           </p>
+          {studyPermission.canCheckAttendance && (
+            <p className="text-sub-2 text-caption-2">
+              ※ 학생 카드의 체크박스를 눌러 출석 체크가 가능해요
+            </p>
+          )}
         </div>
       </div>
     </section>

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -231,7 +231,9 @@ export function SelfStudySection() {
 
           <NoteText>자습 신청 시간은 20:00 ~ 21:00 입니다</NoteText>
           {studyPermission.canCheckAttendance && (
-            <NoteText>학생 카드의 체크박스를 눌러 출석 체크가 가능해요</NoteText>
+            <NoteText>
+              학생 카드의 체크박스를 눌러 출석 체크가 가능해요
+            </NoteText>
           )}
         </div>
       </div>

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -16,6 +16,7 @@ import { useCancelStudy } from "../model/useCancelStudy";
 import { useCheckStudyAttendance } from "../model/useCheckStudyAttendance";
 import { useStudyAttendanceSubscription } from "../model/useStudyAttendanceSubscription";
 import { useUncheckStudyAttendance } from "../model/useUncheckStudyAttendance";
+import { NoteText } from "@/shared/ui/NoteText";
 import { StudyApplicantCard } from "./StudyApplicantCard";
 
 const GRADE_OPTIONS = [1, 2, 3] as const;
@@ -228,13 +229,9 @@ export function SelfStudySection() {
                     : "신청하기"}
           </TextButton>
 
-          <p className="text-sub-2 text-caption-2">
-            ※ 자습 신청 시간은 20:00 ~ 21:00 입니다
-          </p>
+          <NoteText>자습 신청 시간은 20:00 ~ 21:00 입니다</NoteText>
           {studyPermission.canCheckAttendance && (
-            <p className="text-sub-2 text-caption-2">
-              ※ 학생 카드의 체크박스를 눌러 출석 체크가 가능해요
-            </p>
+            <NoteText>학생 카드의 체크박스를 눌러 출석 체크가 가능해요</NoteText>
           )}
         </div>
       </div>

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -229,7 +229,7 @@ export function SelfStudySection() {
           </TextButton>
 
           <p className="text-sub-2 text-caption-2">
-            자습 신청 시간은 20:00 ~ 21:00 입니다
+            ※ 자습 신청 시간은 20:00 ~ 21:00 입니다
           </p>
         </div>
       </div>

--- a/src/features/self-study/ui/StudyBanActionPanel.tsx
+++ b/src/features/self-study/ui/StudyBanActionPanel.tsx
@@ -25,7 +25,7 @@ export function StudyBanActionPanel({
   if (!selectedStudyBanFilter) {
     return (
       <p className="text-caption-3 text-sub-1 font-medium">
-        자습 허용/금지 중 하나를 선택해야 자습 금지/해제가 가능해요.
+        ※ 자습 허용/금지 중 하나를 선택해야 자습 금지/해제가 가능해요.
       </p>
     );
   }

--- a/src/features/self-study/ui/StudyBanActionPanel.tsx
+++ b/src/features/self-study/ui/StudyBanActionPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { TextButton } from "@/shared/ui/Button/TextButton";
+import { NoteText } from "@/shared/ui/NoteText";
 import type { StudyBanFilter } from "@/features/self-study/lib/filterManagedStudents";
 
 interface StudyBanActionPanelProps {
@@ -24,9 +25,9 @@ export function StudyBanActionPanel({
 }: StudyBanActionPanelProps) {
   if (!selectedStudyBanFilter) {
     return (
-      <p className="text-caption-3 text-sub-1 font-medium">
-        ※ 자습 허용/금지 중 하나를 선택해야 자습 금지/해제가 가능해요.
-      </p>
+      <NoteText>
+        자습 허용/금지 중 하나를 선택해야 자습 금지/해제가 가능해요.
+      </NoteText>
     );
   }
 

--- a/src/features/wake-up-music/lib/wakeUpMusicSchema.ts
+++ b/src/features/wake-up-music/lib/wakeUpMusicSchema.ts
@@ -1,3 +1,3 @@
 import { z } from "zod";
 
-export const musicUrlSchema = z.string().min(1);
+export const musicUrlSchema = z.string().trim().min(1);

--- a/src/features/wake-up-music/lib/wakeUpMusicSchema.ts
+++ b/src/features/wake-up-music/lib/wakeUpMusicSchema.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const musicUrlSchema = z.string().min(1);

--- a/src/features/wake-up-music/model/useWakeUpMusic.ts
+++ b/src/features/wake-up-music/model/useWakeUpMusic.ts
@@ -11,11 +11,14 @@ import {
   dormitoryRequests,
 } from "@/entities/dormitory/api/dormitoryQueries";
 import { formatDateParam } from "@/shared/lib/date";
+import { musicUrlSchema } from "@/features/wake-up-music/lib/wakeUpMusicSchema";
 
 export function useWakeUpMusic() {
   const queryClient = useQueryClient();
   const [urlInput, setUrlInput] = useState("");
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+
+  const canApply = musicUrlSchema.safeParse(urlInput).success;
 
   const selectedDateString = formatDateParam(selectedDate);
   const musicQuery = dormitoryQueries.music(selectedDateString);
@@ -66,6 +69,11 @@ export function useWakeUpMusic() {
       toast.error("기상음악 신청에 실패했습니다.");
     },
   });
+
+  const handleApplyMusic = () => {
+    if (!canApply || applyMutation.isPending) return;
+    applyMutation.mutate();
+  };
 
   const handleSubmitRecommendedMusic = async (selectedUrl: string) => {
     await applyRecommendedMutation.mutateAsync({ musicUrl: selectedUrl });
@@ -127,6 +135,9 @@ export function useWakeUpMusic() {
       );
       return { previousSongs };
     },
+    onSuccess: () => {
+      toast.success("기상음악 신청이 취소되었습니다.");
+    },
     onError: (_error, _musicId, context) => {
       if (context?.previousSongs) {
         queryClient.setQueryData(musicQuery.queryKey, context.previousSongs);
@@ -141,10 +152,12 @@ export function useWakeUpMusic() {
   return {
     urlInput,
     setUrlInput,
+    canApply,
     selectedDate,
     setSelectedDate,
     songs,
     applyMutation,
+    handleApplyMusic,
     handleSubmitRecommendedMusic,
     likeMutation,
     cancelMutation,

--- a/src/features/wake-up-music/model/useWakeUpMusic.ts
+++ b/src/features/wake-up-music/model/useWakeUpMusic.ts
@@ -21,6 +21,7 @@ export function useWakeUpMusic() {
   const canApply = musicUrlSchema.safeParse(urlInput).success;
 
   const selectedDateString = formatDateParam(selectedDate);
+  const isToday = selectedDateString === formatDateParam(new Date());
   const musicQuery = dormitoryQueries.music(selectedDateString);
 
   const { data: songs = [] } = useQuery(musicQuery);
@@ -153,6 +154,7 @@ export function useWakeUpMusic() {
     urlInput,
     setUrlInput,
     canApply,
+    isToday,
     selectedDate,
     setSelectedDate,
     songs,

--- a/src/features/wake-up-music/ui/MusicRecommendModal.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendModal.tsx
@@ -99,7 +99,9 @@ export function MusicRecommendModal({
               <Cancel />
             </button>
           </div>
-          <NoteText>노래 추천은 이전에 신청한 곡을 기반으로 노래를 추천해요</NoteText>
+          <NoteText>
+            노래 추천은 이전에 신청한 곡을 기반으로 노래를 추천해요
+          </NoteText>
         </div>
 
         <div className="flex min-h-[230px] gap-3 overflow-x-auto">

--- a/src/features/wake-up-music/ui/MusicRecommendModal.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendModal.tsx
@@ -6,6 +6,7 @@ import MusicRecommendCard from "@/features/wake-up-music/ui/MusicRecommendCard";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import RetryButton from "@/shared/ui/Button/RetryButton";
 import { useAiMusicRecommend } from "@/features/wake-up-music/model/useAiMusicRecommend";
+import { NoteText } from "@/shared/ui/NoteText";
 import { Skeleton } from "@/shared/ui/Skeleton";
 
 interface MusicRecommendModalProps {
@@ -98,9 +99,7 @@ export function MusicRecommendModal({
               <Cancel />
             </button>
           </div>
-          <span className="text-sub-2">
-            ※ 노래 추천은 이전에 신청한 곡을 기반으로 노래를 추천해요
-          </span>
+          <NoteText>노래 추천은 이전에 신청한 곡을 기반으로 노래를 추천해요</NoteText>
         </div>
 
         <div className="flex min-h-[230px] gap-3 overflow-x-auto">

--- a/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
+++ b/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
@@ -22,6 +22,7 @@ export function WakeUpMusicSection({
     urlInput,
     setUrlInput,
     canApply,
+    isToday,
     selectedDate,
     setSelectedDate,
     songs,
@@ -84,7 +85,9 @@ export function WakeUpMusicSection({
             />
             <TextButton
               variant={
-                !canApply || applyMutation.isPending ? "disabled" : "filled"
+                !canApply || applyMutation.isPending || !isToday
+                  ? "disabled"
+                  : "filled"
               }
               size="wide"
               className="w-full"

--- a/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
+++ b/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
@@ -21,10 +21,12 @@ export function WakeUpMusicSection({
   const {
     urlInput,
     setUrlInput,
+    canApply,
     selectedDate,
     setSelectedDate,
     songs,
     applyMutation,
+    handleApplyMusic,
     handleSubmitRecommendedMusic,
     likeMutation,
     cancelMutation,
@@ -81,14 +83,12 @@ export function WakeUpMusicSection({
               onChange={(e) => setUrlInput(e.target.value)}
             />
             <TextButton
-              variant={applyMutation.isPending ? "disabled" : "filled"}
+              variant={
+                !canApply || applyMutation.isPending ? "disabled" : "filled"
+              }
               size="wide"
               className="w-full"
-              onClick={() => {
-                if (!applyMutation.isPending) {
-                  applyMutation.mutate();
-                }
-              }}
+              onClick={handleApplyMusic}
             >
               신청하기
             </TextButton>

--- a/src/shared/ui/Calendar.tsx
+++ b/src/shared/ui/Calendar.tsx
@@ -76,9 +76,17 @@ export function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
         >
           <Back />
         </button>
-        <span className="text-main-text text-text-4">
+        <button
+          type="button"
+          onClick={() => {
+            const today = new Date();
+            setViewDate(today);
+            onDateSelect?.(today);
+          }}
+          className="text-main-text text-text-4 cursor-pointer"
+        >
           {formatHeader(new Date())}
-        </span>
+        </button>
         <button
           type="button"
           onClick={nextMonth}

--- a/src/shared/ui/NoteText.tsx
+++ b/src/shared/ui/NoteText.tsx
@@ -13,7 +13,9 @@ const sizeStyles = {
 
 export function NoteText({ size = "sm", children, className }: NoteTextProps) {
   return (
-    <p className={`text-sub-2 ${sizeStyles[size]}${className ? ` ${className}` : ""}`}>
+    <p
+      className={`text-sub-2 ${sizeStyles[size]}${className ? ` ${className}` : ""}`}
+    >
       ※ {children}
     </p>
   );

--- a/src/shared/ui/NoteText.tsx
+++ b/src/shared/ui/NoteText.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+interface NoteTextProps {
+  size?: "sm" | "md";
+  children: ReactNode;
+  className?: string;
+}
+
+const sizeStyles = {
+  sm: "text-caption-2",
+  md: "text-[15px] font-medium",
+};
+
+export function NoteText({ size = "sm", children, className }: NoteTextProps) {
+  return (
+    <p className={`text-sub-2 ${sizeStyles[size]}${className ? ` ${className}` : ""}`}>
+      ※ {children}
+    </p>
+  );
+}

--- a/src/widgets/main/ui/HomebaseCard.tsx
+++ b/src/widgets/main/ui/HomebaseCard.tsx
@@ -59,35 +59,10 @@ export default function HomebaseCard({
       ? filteredReservations.filter((item) => !myReservationIds.has(item.id))
       : filteredReservations;
 
-  const renderFloor = () => {
-    switch (selectedFloor) {
-      case "2F":
-        return (
-          <SecondFloor
-            selectedTable={selectedTable}
-            onTableSelect={handleTableSelect}
-            reservedTables={reservedTables}
-          />
-        );
-      case "3F":
-        return (
-          <ThirdFloor
-            selectedTable={selectedTable}
-            onTableSelect={handleTableSelect}
-            reservedTables={reservedTables}
-          />
-        );
-      case "4F":
-        return (
-          <FourthFloor
-            selectedTable={selectedTable}
-            onTableSelect={handleTableSelect}
-            reservedTables={reservedTables}
-          />
-        );
-      default:
-        return null;
-    }
+  const floorProps = {
+    selectedTable,
+    onTableSelect: handleTableSelect,
+    reservedTables,
   };
 
   return (
@@ -131,7 +106,9 @@ export default function HomebaseCard({
 
       <div className="mt-3 flex flex-col items-start gap-6 lg:flex-row 2xl:justify-between">
         <div className="flex w-full min-w-0 flex-col gap-4 lg:flex-1">
-          {renderFloor()}
+          {selectedFloor === "2F" && <SecondFloor {...floorProps} />}
+          {selectedFloor === "3F" && <ThirdFloor {...floorProps} />}
+          {selectedFloor === "4F" && <FourthFloor {...floorProps} />}
         </div>
 
         <div className="flex w-full min-w-0 flex-col gap-6 lg:w-82.5 lg:shrink-0 lg:gap-4">
@@ -182,7 +159,7 @@ export default function HomebaseCard({
               >
                 {triedToOverfill && isFull
                   ? `※ 테이블 ${selectedTable}번의 최대인원은 ${maxPersonnel}명입니다`
-                  : "※ 홈베이스 신청시 연속 신청이 가능해요"}
+                  : "※ 테이블을 선택하면 여러 교시를 선택할 수 있어요"}
               </span>
             </div>
           </div>

--- a/src/widgets/main/ui/MassageApplyCard.tsx
+++ b/src/widgets/main/ui/MassageApplyCard.tsx
@@ -52,7 +52,7 @@ export default function MassageApplyCard() {
       icon={<ChairIcon />}
       current={applicants.length}
       total={MASSAGE_MAX}
-      timeText="안마 의자 신청 시간은 20:20 ~ 21:00에 신청이 가능해요"
+      timeText="※ 안마의자 신청 시간은 20:20 ~ 21:00에 신청이 가능해요"
       buttonText={
         isMassageLoading
           ? "확인 중"

--- a/src/widgets/main/ui/MealCard.tsx
+++ b/src/widgets/main/ui/MealCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import Bowl from "@/shared/asset/svg/Bowl";
 import Back from "@/shared/asset/svg/Back";
@@ -18,6 +18,7 @@ import {
 } from "@/shared/ui/QueryErrorBoundary";
 import { Skeleton } from "@/shared/ui/Skeleton";
 import { formatDateParam, formatDisplayDate } from "@/shared/lib/date";
+import { useDebouncedValue } from "@/shared/lib/useDebouncedValue";
 
 function MealCardLoading() {
   return (
@@ -65,6 +66,51 @@ function MealCardEmpty() {
   );
 }
 
+function MealContentLoading() {
+  return (
+    <div className="flex flex-1 flex-col overflow-y-auto">
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 lg:flex lg:flex-col lg:gap-3">
+        {Array.from({ length: 8 }).map((_, index) => (
+          <Skeleton key={index} className="h-6 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface MealCardContentProps {
+  dateStr: string;
+  selectedTab: MealType;
+}
+
+function MealCardContent({ dateStr, selectedTab }: MealCardContentProps) {
+  const { data: meals } = useSuspenseQuery(neisQueries.meals(dateStr));
+
+  const selectedMeal = meals?.find(
+    (m) => m.mealType === MEAL_TYPE_MAP[selectedTab],
+  );
+  const menuItems = selectedMeal?.menus ?? [];
+
+  return (
+    <div className="flex flex-1 flex-col overflow-y-auto">
+      {menuItems.length > 0 ? (
+        <ul className="grid grid-cols-2 gap-x-6 gap-y-3 lg:flex lg:flex-col lg:gap-3">
+          {menuItems.map((item, index) => (
+            <li
+              key={`${item}-${index}`}
+              className="text-text-1 text-sub-1 font-semibold"
+            >
+              {item}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <MealCard.Empty />
+      )}
+    </div>
+  );
+}
+
 const MealCard = () => {
   const [initialMealSelection] = useState(getCurrentMealSelection);
   const [offset, setOffset] = useState(initialMealSelection.dateOffset);
@@ -74,14 +120,11 @@ const MealCard = () => {
 
   const currentDate = new Date();
   currentDate.setDate(currentDate.getDate() + offset);
-  const dateStr = formatDateParam(currentDate);
 
-  const { data: meals } = useSuspenseQuery(neisQueries.meals(dateStr));
-
-  const selectedMeal = meals?.find(
-    (m) => m.mealType === MEAL_TYPE_MAP[selectedTab],
-  );
-  const menuItems = selectedMeal?.menus ?? [];
+  const debouncedOffset = useDebouncedValue(offset, 300);
+  const debouncedDate = new Date();
+  debouncedDate.setDate(debouncedDate.getDate() + debouncedOffset);
+  const dateStr = formatDateParam(debouncedDate);
 
   return (
     <div className="bg-background-surface flex h-[300px] w-full flex-col rounded-2xl p-6 lg:h-[498px]">
@@ -128,22 +171,9 @@ const MealCard = () => {
         ))}
       </div>
 
-      <div className="flex flex-1 flex-col overflow-y-auto">
-        {menuItems.length > 0 ? (
-          <ul className="grid grid-cols-2 gap-x-6 gap-y-3 lg:flex lg:flex-col lg:gap-3">
-            {menuItems.map((item, index) => (
-              <li
-                key={`${item}-${index}`}
-                className="text-text-1 text-sub-1 font-semibold"
-              >
-                {item}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <MealCard.Empty />
-        )}
-      </div>
+      <Suspense fallback={<MealContentLoading />}>
+        <MealCardContent dateStr={dateStr} selectedTab={selectedTab} />
+      </Suspense>
     </div>
   );
 };

--- a/src/widgets/main/ui/ProfileCard.tsx
+++ b/src/widgets/main/ui/ProfileCard.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import ProfileSvg from "@/shared/asset/svg/Profile";
-import More from "@/shared/asset/svg/MoreVertical";
+// import More from "@/shared/asset/svg/MoreVertical";
 import { userQueries } from "@/entities/user/api/userQueries";
 import { getRoleLabel } from "@/entities/user/lib/userRole";
 
@@ -33,9 +33,9 @@ export default function ProfileCard() {
           )}
         </div>
       </div>
-      <div className="ml-auto">
+      {/* <div className="ml-auto">
         <More />
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/src/widgets/main/ui/StudyApplyCard.tsx
+++ b/src/widgets/main/ui/StudyApplyCard.tsx
@@ -53,7 +53,7 @@ export default function StudyApplyCard() {
       icon={<BookIcon />}
       current={students.length}
       total={STUDY_MAX}
-      timeText="자습 신청 시간은 20:00 ~ 21:00에 신청이 가능해요"
+      timeText="※ 자습 신청 시간은 20:00 ~ 21:00에 신청이 가능해요"
       buttonText={
         isStudyBanned
           ? "자습 금지를 당했어요!"

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import Back from "@/shared/asset/svg/Back";
 import Calendar from "@/shared/asset/svg/Calender";
@@ -20,6 +20,7 @@ import {
 } from "@/shared/ui/QueryErrorBoundary";
 import { Skeleton } from "@/shared/ui/Skeleton";
 import { formatDateParam, formatDisplayDate } from "@/shared/lib/date";
+import { useDebouncedValue } from "@/shared/lib/useDebouncedValue";
 
 function TimeTableCardLoading() {
   return (
@@ -70,15 +71,107 @@ function TimeTableCardEmpty() {
   );
 }
 
+function TimeTableContentLoading() {
+  return (
+    <div className="flex h-auto flex-1 flex-col gap-3 overflow-auto 2xl:h-[262px] 2xl:flex-none">
+      <Skeleton className="h-[58px] w-full shrink-0 rounded-lg" />
+      {Array.from({ length: 3 }).map((_, index) => (
+        <Skeleton
+          key={index}
+          className="hidden h-[58px] w-full shrink-0 rounded-lg 2xl:block"
+        />
+      ))}
+    </div>
+  );
+}
+
+interface TimeTableCardContentProps {
+  canFetchTimetable: boolean;
+  timetableParams: {
+    officeCode: string;
+    schoolCode: string;
+    grade: number;
+    classNumber: number;
+    date: string;
+  };
+  currentPeriod: number | null;
+}
+
+function TimeTableCardContent({
+  canFetchTimetable,
+  timetableParams,
+  currentPeriod,
+}: TimeTableCardContentProps) {
+  const activeRef = useRef<HTMLDivElement>(null);
+
+  const timetableQuery = neisQueries.timetables(timetableParams);
+  const { data: timetables } = useSuspenseQuery({
+    ...timetableQuery,
+    queryKey: canFetchTimetable
+      ? timetableQuery.queryKey
+      : ["neis", "timetables", "empty", timetableParams.date],
+    queryFn: () =>
+      canFetchTimetable ? getTimetables(timetableParams) : Promise.resolve([]),
+  });
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, [currentPeriod, timetables]);
+
+  return (
+    <div className="flex h-auto flex-1 flex-col gap-3 overflow-auto 2xl:h-[262px] 2xl:flex-none">
+      {!canFetchTimetable ? (
+        <TimeTableCard.Empty />
+      ) : timetables.length > 0 ? (
+        timetables.map((it) => {
+          const active = it.period === currentPeriod;
+          const times = PERIOD_TIMES[it.period];
+          return (
+            <div
+              key={it.period}
+              ref={active ? activeRef : undefined}
+              className={`bg-sub-4 flex items-center justify-between rounded-lg px-6 py-4 ${
+                active ? "border-p-1 border" : ""
+              }`}
+            >
+              <div className="flex items-center gap-1">
+                <span className="text-sub-1 text-text-3 font-medium">
+                  {it.period} 교시
+                </span>
+                {times && (
+                  <span className="text-caption-1 text-sub-2 font-medium">
+                    {times[0]} ~ {times[1]}
+                  </span>
+                )}
+              </div>
+              <div className="text-sub-1 text-text-4 flex items-center gap-1 font-medium">
+                <span>{it.subject}</span>
+                <span className="text-caption-1 text-sub-2 font-medium">
+                  {it.teacher}
+                </span>
+              </div>
+            </div>
+          );
+        })
+      ) : (
+        <TimeTableCard.Empty />
+      )}
+    </div>
+  );
+}
+
 const TimeTableCard = () => {
   const [offset, setOffset] = useState(0);
-  const activeRef = useRef<HTMLDivElement>(null);
 
   const currentDate = new Date();
   currentDate.setDate(currentDate.getDate() + offset);
-  const dateStr = formatDateParam(currentDate);
 
-  const currentPeriod = offset === 0 ? getCurrentPeriod() : null;
+  const debouncedOffset = useDebouncedValue(offset, 300);
+  const debouncedDate = new Date();
+  debouncedDate.setDate(debouncedDate.getDate() + debouncedOffset);
+  const dateStr = formatDateParam(debouncedDate);
+
+  const currentPeriod = debouncedOffset === 0 ? getCurrentPeriod() : null;
 
   const { data: user } = useSuspenseQuery(userQueries.me());
   const canFetchTimetable = !!user.grade && !!user.classNumber;
@@ -89,19 +182,6 @@ const TimeTableCard = () => {
     classNumber: user.classNumber ?? 0,
     date: dateStr,
   };
-  const timetableQuery = neisQueries.timetables(timetableParams);
-  const { data: timetables } = useSuspenseQuery({
-    ...timetableQuery,
-    queryKey: canFetchTimetable
-      ? timetableQuery.queryKey
-      : ["neis", "timetables", "empty", dateStr],
-    queryFn: () =>
-      canFetchTimetable ? getTimetables(timetableParams) : Promise.resolve([]),
-  });
-
-  useEffect(() => {
-    activeRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-  }, [currentPeriod, timetables]);
 
   return (
     <div className="bg-background-surface flex h-[140px] w-full flex-col rounded-2xl p-6 2xl:block 2xl:h-[354px]">
@@ -132,44 +212,13 @@ const TimeTableCard = () => {
         </div>
       </div>
 
-      <div className="flex h-auto flex-1 flex-col gap-3 overflow-auto 2xl:h-[262px] 2xl:flex-none">
-        {!canFetchTimetable ? (
-          <TimeTableCard.Empty />
-        ) : timetables.length > 0 ? (
-          timetables.map((it) => {
-            const active = it.period === currentPeriod;
-            const times = PERIOD_TIMES[it.period];
-            return (
-              <div
-                key={it.period}
-                ref={active ? activeRef : undefined}
-                className={`bg-sub-4 flex items-center justify-between rounded-lg px-6 py-4 ${
-                  active ? "border-p-1 border" : ""
-                }`}
-              >
-                <div className="flex items-center gap-1">
-                  <span className="text-sub-1 text-text-3 font-medium">
-                    {it.period} 교시
-                  </span>
-                  {times && (
-                    <span className="text-caption-1 text-sub-2 font-medium">
-                      {times[0]} ~ {times[1]}
-                    </span>
-                  )}
-                </div>
-                <div className="text-sub-1 text-text-4 flex items-center gap-1 font-medium">
-                  <span>{it.subject}</span>
-                  <span className="text-caption-1 text-sub-2 font-medium">
-                    {it.teacher}
-                  </span>
-                </div>
-              </div>
-            );
-          })
-        ) : (
-          <TimeTableCard.Empty />
-        )}
-      </div>
+      <Suspense fallback={<TimeTableContentLoading />}>
+        <TimeTableCardContent
+          canFetchTimetable={canFetchTimetable}
+          timetableParams={timetableParams}
+          currentPeriod={currentPeriod}
+        />
+      </Suspense>
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

**기상음악**
- 기상음악 URL 입력 스키마(`musicUrlSchema`) 추가 및 삭제 성공 토스트 처리
- 기상음악 URL 유효성 검증 실패 시 버튼 비활성화 대신 토스트 출력으로 변경
- 사용자의 기상음악 빈 요청 방지
- 오늘이 아닌 날짜 선택 시 기상음악 신청 버튼 비활성화
- 기상음악 썸네일 클릭 시 YouTube로 이동
- 날짜 변경 시 디바운싱 및 Suspense 분리로 로딩 UX 개선
- 달력 상단 날짜 클릭 시 오늘 날짜로 이동

**홈베이스**
- `canSubmit`에 `homebaseReservationDraftSchema` 검증 조건 추가, 검증 실패 시 토스트 출력
- `HomebaseCard` `renderFloor` 인라인 함수 제거로 React Compiler 오류 수정
- 테이블 선택 토스트가 먼저 표기되도록 순서 변경
- 교시 선택 안내 문구 수정 (테이블 선택 시 여러 교시 선택 가능 안내)

**공통 / 기타**
- 당구장 표시 텍스트 `NoteText` 공통 컴포넌트 추가 및 적용
- 자습 관리가 가능할 경우 사용 방법 표시
- 안마의자·자습 신청 시간 안내 문구 `※` 접두사로 통일
- R2 이미지 허용 패턴 추가 (`next.config.ts`)
- 프로필 크롭 기능 임시 비활성화

### 프로필 크롭 기능 임시 비활성화

<img width="825" height="221" alt="image" src="https://github.com/user-attachments/assets/3b7a7420-403d-4930-ad1a-90a0225a0581" />

## 💬리뷰 요구사항

- `HomebaseCard`의 `renderFloor` 인라인 함수를 `floorProps` + 조건부 렌더링으로 교체한 구조 확인 부탁드립니다.
- `NoteText` 공통 컴포넌트의 `shared` 계층 배치 타당성 확인 부탁드립니다.