### PR TITLE
fix: 학생회 자습 관리 및 학생 관리 UI 접근 제거

### DIFF
--- a/app/(main)/students/page.tsx
+++ b/app/(main)/students/page.tsx
@@ -52,7 +52,7 @@ function StudentsPageContent() {
           <div className="flex flex-col gap-1">
             <h2 className="text-title-3 text-main-text">접근 권한이 없어요</h2>
             <p className="text-text-3 text-sub-1">
-              학생관리는 관리자, 기자위, 학생회 계정에서만 사용할 수 있어요.
+              학생관리는 관리자, 기자위 계정에서만 사용할 수 있어요.
             </p>
           </div>
           <TextButton

--- a/src/entities/dormitory/lib/studyPermission.ts
+++ b/src/entities/dormitory/lib/studyPermission.ts
@@ -5,10 +5,7 @@ interface CreateStudyPermissionParams {
 }
 
 export function createStudyPermission({ role }: CreateStudyPermissionParams) {
-  const isManager =
-    role === "ADMIN" ||
-    role === "DORMITORY_MANAGER" ||
-    role === "STUDENT_COUNCIL";
+  const isManager = role === "ADMIN" || role === "DORMITORY_MANAGER";
 
   return {
     isManager,


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- `STUDENT_COUNCIL` 역할을 `isManager` 조건에서 제거해 학생회 계정의 자습 관리 및 학생 관리 접근 차단
- 사이드바에서 학생회 계정 기준 학생관리 메뉴 미노출
- 자습 섹션에서 학생회 계정의 출석 체크 권한 제거
- 학생관리 페이지 접근 제한 안내 문구에서 "학생회" 문구 제거