### PR TITLE
fix: 기상음악 목록 기본 날짜 UX 개선 (7:25 이전 전날 표시)

### DIFF
--- a/src/features/wake-up-music/lib/date.ts
+++ b/src/features/wake-up-music/lib/date.ts
@@ -1,0 +1,20 @@
+const WAKE_UP_HOUR = 7;
+const WAKE_UP_MINUTE = 25;
+
+export function getInitialMusicDate(): Date {
+  const now = new Date();
+  const utc = now.getTime() + now.getTimezoneOffset() * 60000;
+  const kst = new Date(utc + 9 * 60 * 60 * 1000);
+
+  const isBeforeWakeUp =
+    kst.getHours() < WAKE_UP_HOUR ||
+    (kst.getHours() === WAKE_UP_HOUR && kst.getMinutes() < WAKE_UP_MINUTE);
+
+  if (isBeforeWakeUp) {
+    const yesterday = new Date(now);
+    yesterday.setDate(now.getDate() - 1);
+    return yesterday;
+  }
+
+  return now;
+}

--- a/src/features/wake-up-music/model/useWakeUpMusic.ts
+++ b/src/features/wake-up-music/model/useWakeUpMusic.ts
@@ -10,13 +10,13 @@ import {
   dormitoryMutations,
   dormitoryRequests,
 } from "@/entities/dormitory/api/dormitoryQueries";
-import { formatDateParam } from "@/shared/lib/date";
+import { formatDateParam, getInitialMusicDate } from "@/shared/lib/date";
 import { musicUrlSchema } from "@/features/wake-up-music/lib/wakeUpMusicSchema";
 
 export function useWakeUpMusic() {
   const queryClient = useQueryClient();
   const [urlInput, setUrlInput] = useState("");
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date>(getInitialMusicDate);
 
   const canApply = musicUrlSchema.safeParse(urlInput).success;
 

--- a/src/features/wake-up-music/model/useWakeUpMusic.ts
+++ b/src/features/wake-up-music/model/useWakeUpMusic.ts
@@ -10,7 +10,8 @@ import {
   dormitoryMutations,
   dormitoryRequests,
 } from "@/entities/dormitory/api/dormitoryQueries";
-import { formatDateParam, getInitialMusicDate } from "@/shared/lib/date";
+import { formatDateParam } from "@/shared/lib/date";
+import { getInitialMusicDate } from "@/features/wake-up-music/lib/date";
 import { musicUrlSchema } from "@/features/wake-up-music/lib/wakeUpMusicSchema";
 
 export function useWakeUpMusic() {

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -24,25 +24,6 @@ export function formatDateParam(
   return `${formattedDate} ${timeParts.join(":")}`;
 }
 
-// 기상음악 재생 시각(07:25) 이전에는 전날 날짜를 기본으로 보여준다.
-const WAKE_UP_HOUR = 7;
-const WAKE_UP_MINUTE = 25;
-
-export function getInitialMusicDate(): Date {
-  const now = new Date();
-  const isBeforeWakeUp =
-    now.getHours() < WAKE_UP_HOUR ||
-    (now.getHours() === WAKE_UP_HOUR && now.getMinutes() < WAKE_UP_MINUTE);
-
-  if (isBeforeWakeUp) {
-    const yesterday = new Date(now);
-    yesterday.setDate(now.getDate() - 1);
-    return yesterday;
-  }
-
-  return now;
-}
-
 export const DAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
 export function formatDisplayDate(date: Date): string {

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -24,6 +24,25 @@ export function formatDateParam(
   return `${formattedDate} ${timeParts.join(":")}`;
 }
 
+// 기상음악 재생 시각(07:25) 이전에는 전날 날짜를 기본으로 보여준다.
+const WAKE_UP_HOUR = 7;
+const WAKE_UP_MINUTE = 25;
+
+export function getInitialMusicDate(): Date {
+  const now = new Date();
+  const isBeforeWakeUp =
+    now.getHours() < WAKE_UP_HOUR ||
+    (now.getHours() === WAKE_UP_HOUR && now.getMinutes() < WAKE_UP_MINUTE);
+
+  if (isBeforeWakeUp) {
+    const yesterday = new Date(now);
+    yesterday.setDate(now.getDate() - 1);
+    return yesterday;
+  }
+
+  return now;
+}
+
 export const DAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
 export function formatDisplayDate(date: Date): string {


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 오전 7:25 이전에는 기상음악 목록의 기본 표시 날짜를 전날로 설정하여, 당일 기상음악을 확인할 수 있도록 개선
- `shared/lib/date.ts`에 `getInitialMusicDate()` 헬퍼 추가 — 현재 시각이 07:25 미만이면 전날 `Date` 반환
- `useWakeUpMusic` 훅의 `selectedDate` 초기값을 `new Date()` 대신 `getInitialMusicDate`로 교체


### 다음날 오전 7:25 이전까지 전날 신청 음악 표시
<img width="2442" height="821" alt="image" src="https://github.com/user-attachments/assets/d84d4227-c4ba-4802-a4a2-5a2bc2a5ca80" />


## 💬리뷰 요구사항

- 기상 시각(07:25)을 모듈 상수로 분리했습니다. 추후 변경 가능성이 있다면 shared config로 이동하는 것도 고려 부탁드립니다.