### PR TITLE
fix: 홈베이스 신청 불가 시간대에 층/교시/신청 버튼 비활성화

### DIFF
--- a/src/features/homebase/lib/isPeriodStarted.ts
+++ b/src/features/homebase/lib/isPeriodStarted.ts
@@ -10,7 +10,6 @@ export function isPeriodStarted(period: string): boolean {
   return now >= periodTime;
 }
 
-
 export function isAllPeriodsStarted(): boolean {
   return PERIODS.every(isPeriodStarted);
 }

--- a/src/features/homebase/lib/isPeriodStarted.ts
+++ b/src/features/homebase/lib/isPeriodStarted.ts
@@ -1,4 +1,4 @@
-import { PERIODS_TIME } from "../model/constants";
+import { PERIODS, PERIODS_TIME } from "../model/constants";
 
 export function isPeriodStarted(period: string): boolean {
   const timeStr = PERIODS_TIME[period];
@@ -8,4 +8,9 @@ export function isPeriodStarted(period: string): boolean {
   const periodTime = new Date();
   periodTime.setHours(hour, minute, 0, 0);
   return now >= periodTime;
+}
+
+
+export function isAllPeriodsStarted(): boolean {
+  return PERIODS.every(isPeriodStarted);
 }

--- a/src/features/homebase/lib/isPeriodStarted.ts
+++ b/src/features/homebase/lib/isPeriodStarted.ts
@@ -1,26 +1,18 @@
-import {
-  PERIODS,
-  PERIODS_TIME,
-  RESERVATION_OPEN_TIME,
-} from "../model/constants";
+import { HOMEBASE_SCHEDULE, PERIODS } from "../model/constants";
 
-function isBeforeReservationOpen(): boolean {
-  const [hour, minute] = RESERVATION_OPEN_TIME.split(":").map(Number);
+function isPastTime(timeStr: string): boolean {
+  const [hour, minute] = timeStr.split(":").map(Number);
   const now = new Date();
-  const openTime = new Date();
-  openTime.setHours(hour, minute, 0, 0);
-  return now < openTime;
+  const target = new Date();
+  target.setHours(hour, minute, 0, 0);
+  return now >= target;
 }
 
 export function isPeriodStarted(period: string): boolean {
-  if (isBeforeReservationOpen()) return true;
-  const timeStr = PERIODS_TIME[period];
-  if (!timeStr) return false;
-  const now = new Date();
-  const [hour, minute] = timeStr.split(":").map(Number);
-  const periodTime = new Date();
-  periodTime.setHours(hour, minute, 0, 0);
-  return now >= periodTime;
+  if (!isPastTime(HOMEBASE_SCHEDULE.periods["5교시"].start)) return true;
+  const schedule = HOMEBASE_SCHEDULE.periods[period];
+  if (!schedule) return false;
+  return isPastTime(schedule.start);
 }
 
 export function isAllPeriodsStarted(): boolean {

--- a/src/features/homebase/lib/isPeriodStarted.ts
+++ b/src/features/homebase/lib/isPeriodStarted.ts
@@ -1,6 +1,19 @@
-import { PERIODS, PERIODS_TIME } from "../model/constants";
+import {
+  PERIODS,
+  PERIODS_TIME,
+  RESERVATION_OPEN_TIME,
+} from "../model/constants";
+
+function isBeforeReservationOpen(): boolean {
+  const [hour, minute] = RESERVATION_OPEN_TIME.split(":").map(Number);
+  const now = new Date();
+  const openTime = new Date();
+  openTime.setHours(hour, minute, 0, 0);
+  return now < openTime;
+}
 
 export function isPeriodStarted(period: string): boolean {
+  if (isBeforeReservationOpen()) return true;
   const timeStr = PERIODS_TIME[period];
   if (!timeStr) return false;
   const now = new Date();

--- a/src/features/homebase/model/constants.ts
+++ b/src/features/homebase/model/constants.ts
@@ -6,6 +6,8 @@ export const FLOORS = [
 
 export const PERIODS = ["8교시", "9교시", "10교시", "11교시"];
 
+export const RESERVATION_OPEN_TIME = "13:30";
+
 export const PERIODS_TIME: Record<string, string> = {
   "8교시": "16:40",
   "9교시": "17:40",

--- a/src/features/homebase/model/constants.ts
+++ b/src/features/homebase/model/constants.ts
@@ -4,16 +4,17 @@ export const FLOORS = [
   { value: "4F", label: "4층" },
 ];
 
-export const PERIODS = ["8교시", "9교시", "10교시", "11교시"];
-
-export const RESERVATION_OPEN_TIME = "13:30";
-
-export const PERIODS_TIME: Record<string, string> = {
-  "8교시": "16:40",
-  "9교시": "17:40",
-  "10교시": "19:30",
-  "11교시": "20:30",
+export const HOMEBASE_SCHEDULE = {
+  periods: {
+    "5교시": { start: "13:30", end: "14:20" },
+    "8교시": { start: "16:40", end: "17:30" },
+    "9교시": { start: "17:40", end: "18:30" },
+    "10교시": { start: "19:30", end: "20:20" },
+    "11교시": { start: "20:30", end: "21:20" },
+  } as Record<string, { start: string; end: string }>,
 };
+
+export const PERIODS = ["8교시", "9교시", "10교시", "11교시"];
 
 export const TABLE_MAX_PERSONNEL = {
   "2F": { "1": 6, "2": 4, "3": 4 },

--- a/src/features/homebase/model/useHomebaseReservation.ts
+++ b/src/features/homebase/model/useHomebaseReservation.ts
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { getMaxPersonnel } from "@/features/homebase/lib/getMaxPersonnel";
+import { isAllPeriodsStarted } from "@/features/homebase/lib/isPeriodStarted";
 import { useHomebasePeriodSelection } from "@/features/homebase/model/useHomebasePeriodSelection";
 import { useHomebaseReservationActions } from "@/features/homebase/model/useHomebaseReservationActions";
 import { useHomebaseReservationData } from "@/features/homebase/model/useHomebaseReservationData";
@@ -106,6 +107,8 @@ export function useHomebaseReservation() {
     setSelectedTable(null);
   };
 
+  const isApplicationClosed = isAllPeriodsStarted();
+
   const { canSubmit, handleSubmit, handleDeleteReservation } =
     useHomebaseReservationActions({
       selectedFloor,
@@ -137,6 +140,7 @@ export function useHomebaseReservation() {
     myReservationIds,
     isLoading,
     isError,
+    isApplicationClosed,
     canSubmit,
     selectedStudents,
     handleFloorChange,

--- a/src/features/homebase/model/useHomebaseReservationActions.ts
+++ b/src/features/homebase/model/useHomebaseReservationActions.ts
@@ -99,7 +99,10 @@ export function useHomebaseReservationActions({
     },
     onError: () => toast.error("취소에 실패했습니다. 다시 시도해주세요"),
   });
-  const canSubmit = homebasePermission.canReserve && !applyMutation.isPending;
+  const canSubmit =
+    homebasePermission.canReserve &&
+    !applyMutation.isPending &&
+    !isPeriodStarted(selectedStartPeriod);
 
   const handleSubmit = () => {
     if (!homebasePermission.canReserve || applyMutation.isPending) return;

--- a/src/features/homebase/model/useHomebaseReservationActions.ts
+++ b/src/features/homebase/model/useHomebaseReservationActions.ts
@@ -119,7 +119,7 @@ export function useHomebaseReservationActions({
     }
 
     if (isPeriodStarted(selectedStartPeriod)) {
-      toast.warning("이미 지난 교시는 신청할 수 없습니다");
+      toast.warning("지금은 신청할 수 없는 시간대입니다");
       return;
     }
 

--- a/src/shared/ui/NoteText.tsx
+++ b/src/shared/ui/NoteText.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 interface NoteTextProps {
   size?: "sm" | "md";
+  tone?: "default" | "negative" | "primary";
   children: ReactNode;
   className?: string;
 }
@@ -11,10 +12,21 @@ const sizeStyles = {
   md: "text-[15px] font-medium",
 };
 
-export function NoteText({ size = "sm", children, className }: NoteTextProps) {
+const toneStyles = {
+  default: "text-sub-2",
+  negative: "text-negative",
+  primary: "text-p-1",
+};
+
+export function NoteText({
+  size = "sm",
+  tone = "default",
+  children,
+  className,
+}: NoteTextProps) {
   return (
     <p
-      className={`text-sub-2 ${sizeStyles[size]}${className ? ` ${className}` : ""}`}
+      className={`${toneStyles[tone]} ${sizeStyles[size]}${className ? ` ${className}` : ""}`}
     >
       ※ {children}
     </p>

--- a/src/widgets/main/ui/ApplyCard.tsx
+++ b/src/widgets/main/ui/ApplyCard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import ChevronRight from "@/shared/asset/svg/Back";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import type { TextButtonVariant } from "@/shared/ui/Button/TextButton";
+import { NoteText } from "@/shared/ui/NoteText";
 
 type ApplyCardButtonSize = "small" | "fit";
 
@@ -78,9 +79,9 @@ export default function ApplyCard({
             {timeText}
           </p>
           {femaleNotice && (
-            <p className="text-caption-3 text-p-1 mt-0.5 line-clamp-1 font-medium">
-              ※ 여학생의 경우 여자 사감선생님께 별도로 신청해주시기 바랍니다.
-            </p>
+            <NoteText tone="primary" className="mt-0.5 line-clamp-1">
+              여학생의 경우 여자 사감선생님께 별도로 신청해주시기 바랍니다.
+            </NoteText>
           )}
         </div>
         <TextButton

--- a/src/widgets/main/ui/HomebaseCard.tsx
+++ b/src/widgets/main/ui/HomebaseCard.tsx
@@ -11,6 +11,7 @@ import { ThirdFloor } from "@/features/homebase/ui/ThirdFloor";
 import HomeBase from "@/shared/asset/svg/HomeBase";
 import Search from "@/shared/asset/svg/Search";
 import { TextButton } from "@/shared/ui/Button/TextButton";
+import { NoteText } from "@/shared/ui/NoteText";
 import { Skeleton } from "@/shared/ui/Skeleton";
 import TextField from "@/shared/ui/textField";
 
@@ -159,15 +160,18 @@ export default function HomebaseCard({
               >
                 신청하기
               </TextButton>
-              <span
-                className={
-                  triedToOverfill && isFull ? "text-negative" : "text-sub-2"
-                }
-              >
-                {triedToOverfill && isFull
-                  ? `※ 테이블 ${selectedTable}번의 최대인원은 ${maxPersonnel}명입니다`
-                  : "※ 테이블을 선택하면 여러 교시를 선택할 수 있어요"}
-              </span>
+              {triedToOverfill && isFull ? (
+                <NoteText tone="negative">
+                  테이블 {selectedTable}번의 최대인원은 {maxPersonnel}명입니다
+                </NoteText>
+              ) : (
+                <NoteText>
+                  테이블을 선택하면 여러 교시를 선택할 수 있어요
+                </NoteText>
+              )}
+              <NoteText>
+                홈베이스 신청은 13:30 이후부터 해당 교시 시작 전 신청이 가능해요
+              </NoteText>
             </div>
           </div>
 

--- a/src/widgets/main/ui/HomebaseCard.tsx
+++ b/src/widgets/main/ui/HomebaseCard.tsx
@@ -169,9 +169,7 @@ export default function HomebaseCard({
                   테이블을 선택하면 여러 교시를 선택할 수 있어요
                 </NoteText>
               )}
-              <NoteText>
-                홈베이스 신청은 13:30 이후부터 해당 교시 시작 전 신청이 가능해요
-              </NoteText>
+              <NoteText>13:30부터 해당 교시 시작 전까지 신청 가능해요</NoteText>
             </div>
           </div>
 

--- a/src/widgets/main/ui/HomebaseCard.tsx
+++ b/src/widgets/main/ui/HomebaseCard.tsx
@@ -39,6 +39,7 @@ export default function HomebaseCard({
     myReservationIds,
     isLoading,
     isError,
+    isApplicationClosed,
     canSubmit,
     selectedStudents,
     handleFloorChange,
@@ -80,7 +81,13 @@ export default function HomebaseCard({
           {FLOORS.map(({ value, label }) => (
             <TextButton
               key={value}
-              variant={selectedFloor === value ? "filled" : "outlined"}
+              variant={
+                isApplicationClosed
+                  ? "disabled"
+                  : selectedFloor === value
+                    ? "filled"
+                    : "outlined"
+              }
               className="w-fit! min-w-[68px]! px-4 sm:min-w-[91px]!"
               onClick={() => handleFloorChange(value)}
             >


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- `isAllPeriodsStarted` 함수 추가: 모든 교시(8~11교시)가 시작된 경우 `true` 반환
- 층 버튼: 모든 교시가 이미 시작된 신청 불가 시간대(20:30 이후)에 `disabled` 처리
- 신청하기 버튼: 선택된 시작 교시가 이미 지난 경우 `canSubmit = false`로 비활성화
- 교시 버튼: 기존에 이미 `isPeriodStarted` 기반으로 `disabled` variant가 적용되어 있어 추가 변경 없음

<img width="1691" height="941" alt="image" src="https://github.com/user-attachments/assets/e138fb06-5b42-4b6e-9e06-cadbcacf290b" />


## 💬리뷰 요구사항

- 층 버튼은 모든 교시가 시작된 경우에만 비활성화됩니다. 예약현황 조회는 여전히 렌더링되므로 UX 흐름에 이상이 없는지 확인 부탁드립니다.