### PR TITLE
fix: 시간 처리를 KST 기준으로 전환

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import "temporal-polyfill/global";
 import type { Metadata } from "next";
 import "@sun-typeface/suit/fonts/variable/woff2/SUIT-Variable.css";
 import "./globals.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "19.2.3",
         "react-dropzone": "^15.0.0",
         "sonner": "^2.0.7",
+        "temporal-polyfill": "^0.3.2",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -8393,6 +8394,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.1"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
     },
     "node_modules/terser": {
       "version": "5.48.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "19.2.3",
     "react-dropzone": "^15.0.0",
     "sonner": "^2.0.7",
+    "temporal-polyfill": "^0.3.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/entities/neis/lib/getCurrentMealType.ts
+++ b/src/entities/neis/lib/getCurrentMealType.ts
@@ -2,6 +2,7 @@ import {
   MEAL_TYPE_END_MINUTES,
   type MealType,
 } from "@/entities/neis/model/neis";
+import { minutesOfDay, nowKst } from "@/shared/lib/kst";
 
 interface CurrentMealSelection {
   mealType: MealType;
@@ -9,9 +10,9 @@ interface CurrentMealSelection {
 }
 
 export function getCurrentMealSelection(
-  now = new Date(),
+  now: Temporal.PlainDateTime = nowKst(),
 ): CurrentMealSelection {
-  const totalMinutes = now.getHours() * 60 + now.getMinutes();
+  const totalMinutes = minutesOfDay(now);
 
   if (totalMinutes <= MEAL_TYPE_END_MINUTES.조식) {
     return { mealType: "조식", dateOffset: 0 };

--- a/src/entities/neis/lib/getCurrentPeriod.ts
+++ b/src/entities/neis/lib/getCurrentPeriod.ts
@@ -1,8 +1,9 @@
 import { PERIOD_TIMES } from "@/entities/neis/model/neis";
+import { nowKst } from "@/shared/lib/kst";
 
 export function getCurrentPeriod(): number | null {
-  const now = new Date();
-  const hhmm = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  const now = nowKst();
+  const hhmm = `${String(now.hour).padStart(2, "0")}:${String(now.minute).padStart(2, "0")}`;
   for (const [period, [start, end]] of Object.entries(PERIOD_TIMES)) {
     if (hhmm >= start && hhmm <= end) return Number(period);
   }

--- a/src/features/club-application/ui/ClubApplicationListSection.tsx
+++ b/src/features/club-application/ui/ClubApplicationListSection.tsx
@@ -10,6 +10,7 @@ import { userQueries } from "@/entities/user/api/userQueries";
 import { createClubPermission } from "@/entities/club/lib/permission";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import { formatDateParam } from "@/shared/lib/date";
+import { parseKstWallClock } from "@/shared/lib/kst";
 import {
   ClientQueryBoundary,
   type QueryErrorFallbackProps,
@@ -23,9 +24,9 @@ interface ClubApplicationListSectionProps {
 }
 
 function formatSubmittedAt(value: string): string {
-  const date = new Date(value);
+  const date = parseKstWallClock(value);
 
-  if (Number.isNaN(date.getTime())) {
+  if (!date) {
     return value;
   }
 

--- a/src/features/homebase/lib/isPeriodStarted.ts
+++ b/src/features/homebase/lib/isPeriodStarted.ts
@@ -1,11 +1,9 @@
+import { minutesOfDay, nowKst } from "@/shared/lib/kst";
 import { HOMEBASE_SCHEDULE, PERIODS } from "../model/constants";
 
 function isPastTime(timeStr: string): boolean {
   const [hour, minute] = timeStr.split(":").map(Number);
-  const now = new Date();
-  const target = new Date();
-  target.setHours(hour, minute, 0, 0);
-  return now >= target;
+  return minutesOfDay(nowKst()) >= hour * 60 + minute;
 }
 
 export function isPeriodStarted(period: string): boolean {

--- a/src/features/homebase/model/useHomebaseReservation.ts
+++ b/src/features/homebase/model/useHomebaseReservation.ts
@@ -9,12 +9,13 @@ import { useHomebaseReservationActions } from "@/features/homebase/model/useHome
 import { useHomebaseReservationData } from "@/features/homebase/model/useHomebaseReservationData";
 import { useHomebaseStudentSelection } from "@/features/homebase/model/useHomebaseStudentSelection";
 import { formatDateParam } from "@/shared/lib/date";
+import { todayKst } from "@/shared/lib/kst";
 
 export function useHomebaseReservation() {
   const [selectedFloor, setSelectedFloor] = useState("2F");
   const [selectedTable, setSelectedTable] = useState<string | null>(null);
   const [reason, setReason] = useState("");
-  const [reservationDate] = useState(() => formatDateParam(new Date()));
+  const [reservationDate] = useState(() => formatDateParam(todayKst()));
   const {
     selectedStartPeriod,
     selectedStartNum,

--- a/src/features/wake-up-music/lib/date.ts
+++ b/src/features/wake-up-music/lib/date.ts
@@ -1,18 +1,19 @@
-import { nowKst, todayKst } from "@/shared/lib/kst";
+import { nowKst } from "@/shared/lib/kst";
 
 const WAKE_UP_HOUR = 7;
 const WAKE_UP_MINUTE = 25;
 
 export function getInitialMusicDate(): Temporal.PlainDate {
   const now = nowKst();
+  const today = now.toPlainDate();
 
   const isBeforeWakeUp =
     now.hour < WAKE_UP_HOUR ||
     (now.hour === WAKE_UP_HOUR && now.minute < WAKE_UP_MINUTE);
 
   if (isBeforeWakeUp) {
-    return todayKst().subtract({ days: 1 });
+    return today.subtract({ days: 1 });
   }
 
-  return todayKst();
+  return today;
 }

--- a/src/features/wake-up-music/lib/date.ts
+++ b/src/features/wake-up-music/lib/date.ts
@@ -1,20 +1,18 @@
+import { nowKst, todayKst } from "@/shared/lib/kst";
+
 const WAKE_UP_HOUR = 7;
 const WAKE_UP_MINUTE = 25;
 
-export function getInitialMusicDate(): Date {
-  const now = new Date();
-  const utc = now.getTime() + now.getTimezoneOffset() * 60000;
-  const kst = new Date(utc + 9 * 60 * 60 * 1000);
+export function getInitialMusicDate(): Temporal.PlainDate {
+  const now = nowKst();
 
   const isBeforeWakeUp =
-    kst.getHours() < WAKE_UP_HOUR ||
-    (kst.getHours() === WAKE_UP_HOUR && kst.getMinutes() < WAKE_UP_MINUTE);
+    now.hour < WAKE_UP_HOUR ||
+    (now.hour === WAKE_UP_HOUR && now.minute < WAKE_UP_MINUTE);
 
   if (isBeforeWakeUp) {
-    const yesterday = new Date(now);
-    yesterday.setDate(now.getDate() - 1);
-    return yesterday;
+    return todayKst().subtract({ days: 1 });
   }
 
-  return now;
+  return todayKst();
 }

--- a/src/features/wake-up-music/model/useWakeUpMusic.ts
+++ b/src/features/wake-up-music/model/useWakeUpMusic.ts
@@ -12,18 +12,20 @@ import {
 } from "@/entities/dormitory/api/dormitoryQueries";
 import { userQueries } from "@/entities/user/api/userQueries";
 import { formatDateParam } from "@/shared/lib/date";
+import { todayKst } from "@/shared/lib/kst";
 import { getInitialMusicDate } from "@/features/wake-up-music/lib/date";
 import { musicUrlSchema } from "@/features/wake-up-music/lib/wakeUpMusicSchema";
 
 export function useWakeUpMusic() {
   const queryClient = useQueryClient();
   const [urlInput, setUrlInput] = useState("");
-  const [selectedDate, setSelectedDate] = useState<Date>(getInitialMusicDate);
+  const [selectedDate, setSelectedDate] =
+    useState<Temporal.PlainDate>(getInitialMusicDate);
 
   const canApply = musicUrlSchema.safeParse(urlInput).success;
 
   const selectedDateString = formatDateParam(selectedDate);
-  const isToday = selectedDateString === formatDateParam(new Date());
+  const isToday = selectedDateString === formatDateParam(todayKst());
   const musicQuery = dormitoryQueries.music(selectedDateString);
 
   const { data: songs = [] } = useQuery(musicQuery);

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -3,19 +3,27 @@ interface FormatDateParamOptions {
   minute?: boolean;
 }
 
+type DateLike = Temporal.PlainDate | Temporal.PlainDateTime;
+
+function hasTime(date: DateLike): date is Temporal.PlainDateTime {
+  return "hour" in date;
+}
+
 export function formatDateParam(
-  date: Date,
+  date: DateLike,
   options: FormatDateParamOptions = {},
 ): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+  const year = date.year;
+  const month = String(date.month).padStart(2, "0");
+  const day = String(date.day).padStart(2, "0");
   const formattedDate = `${year}-${month}-${day}`;
 
-  const timeParts = [
-    options.hour && String(date.getHours()).padStart(2, "0"),
-    options.minute && String(date.getMinutes()).padStart(2, "0"),
-  ].filter(Boolean);
+  const timeParts = hasTime(date)
+    ? [
+        options.hour && String(date.hour).padStart(2, "0"),
+        options.minute && String(date.minute).padStart(2, "0"),
+      ].filter(Boolean)
+    : [];
 
   if (timeParts.length === 0) {
     return formattedDate;
@@ -26,10 +34,11 @@ export function formatDateParam(
 
 export const DAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
-export function formatDisplayDate(date: Date): string {
-  const yy = String(date.getFullYear()).slice(2);
-  const mm = String(date.getMonth() + 1).padStart(2, "0");
-  const dd = String(date.getDate()).padStart(2, "0");
-  const day = DAYS[date.getDay()];
+export function formatDisplayDate(date: DateLike): string {
+  const yy = String(date.year).slice(2);
+  const mm = String(date.month).padStart(2, "0");
+  const dd = String(date.day).padStart(2, "0");
+  // Temporal의 dayOfWeek는 1(월)~7(일) → DAYS(0=일)에 맞춰 매핑
+  const day = DAYS[date.dayOfWeek % 7];
   return `${yy}.${mm}.${dd} (${day})`;
 }

--- a/src/shared/lib/kst.ts
+++ b/src/shared/lib/kst.ts
@@ -1,0 +1,36 @@
+const KST_TIME_ZONE = "Asia/Seoul";
+
+/**
+ * 실행 환경(브라우저/SSR Node)의 타임존과 무관하게 KST 벽시계를 반환한다.
+ */
+export function nowKst(): Temporal.PlainDateTime {
+  return Temporal.Now.plainDateTimeISO(KST_TIME_ZONE);
+}
+
+/**
+ * 환경 타임존과 무관한 KST 기준 오늘 날짜를 반환한다.
+ */
+export function todayKst(): Temporal.PlainDate {
+  return Temporal.Now.plainDateISO(KST_TIME_ZONE);
+}
+
+/**
+ * 백엔드가 주는 오프셋 없는 KST 벽시계 문자열을 파싱한다.
+ * 추가 타임존 보정 없이 그대로 KST로 해석하며, 잘못된 값이면 null을 반환한다.
+ */
+export function parseKstWallClock(
+  value: string,
+): Temporal.PlainDateTime | null {
+  try {
+    return Temporal.PlainDateTime.from(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 자정 기준 분(minute) 값으로 변환한다. (시간 구간 비교용)
+ */
+export function minutesOfDay(dateTime: Temporal.PlainDateTime): number {
+  return dateTime.hour * 60 + dateTime.minute;
+}

--- a/src/shared/lib/timeWindow.ts
+++ b/src/shared/lib/timeWindow.ts
@@ -1,3 +1,5 @@
+import { minutesOfDay } from "@/shared/lib/kst";
+
 export interface TimeOfDay {
   hour: number;
   minute: number;
@@ -12,11 +14,11 @@ export function isTimeInWindow({
   start,
   end,
 }: {
-  date: Date;
+  date: Temporal.PlainDateTime;
   start: TimeOfDay;
   end: TimeOfDay;
 }): boolean {
-  const currentMinutes = date.getHours() * 60 + date.getMinutes();
+  const currentMinutes = minutesOfDay(date);
 
   return currentMinutes >= toMinutes(start) && currentMinutes < toMinutes(end);
 }

--- a/src/shared/lib/useCurrentTime.ts
+++ b/src/shared/lib/useCurrentTime.ts
@@ -1,13 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { nowKst } from "@/shared/lib/kst";
 
-export function useCurrentTime(intervalMs = 5_000): Date {
-  const [currentTime, setCurrentTime] = useState(() => new Date());
+export function useCurrentTime(intervalMs = 5_000): Temporal.PlainDateTime {
+  const [currentTime, setCurrentTime] = useState(nowKst);
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
-      setCurrentTime(new Date());
+      setCurrentTime(nowKst());
     }, intervalMs);
 
     return () => window.clearInterval(intervalId);

--- a/src/shared/ui/Calendar.tsx
+++ b/src/shared/ui/Calendar.tsx
@@ -2,69 +2,51 @@
 
 import { useState } from "react";
 import Back from "@/shared/asset/svg/Back";
+import { todayKst } from "@/shared/lib/kst";
 
 interface CalendarProps {
-  selectedDate?: Date;
-  onDateSelect?: (date: Date) => void;
+  selectedDate?: Temporal.PlainDate;
+  onDateSelect?: (date: Temporal.PlainDate) => void;
 }
 
 const DAY_LABELS = ["월", "화", "수", "목", "금", "토", "일"];
 
 const DAY_KO = ["일", "월", "화", "수", "목", "금", "토"];
 
-function buildCalendarGrid(viewDate: Date): Date[] {
-  const year = viewDate.getFullYear();
-  const month = viewDate.getMonth();
-  const firstDay = new Date(year, month, 1).getDay();
-  const offset = firstDay === 0 ? 6 : firstDay - 1;
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
-  const prevMonthDays = new Date(year, month, 0).getDate();
+function buildCalendarGrid(viewDate: Temporal.PlainDate): Temporal.PlainDate[] {
+  const firstOfMonth = viewDate.with({ day: 1 });
+  // dayOfWeek: 1(월)~7(일) → 월요일 시작 그리드 오프셋
+  const offset = firstOfMonth.dayOfWeek - 1;
+  const start = firstOfMonth.subtract({ days: offset });
 
-  const cells: Date[] = [];
+  const totalCells = Math.ceil((offset + viewDate.daysInMonth) / 7) * 7;
 
-  for (let i = offset - 1; i >= 0; i--) {
-    cells.push(new Date(year, month - 1, prevMonthDays - i));
-  }
-  for (let d = 1; d <= daysInMonth; d++) {
-    cells.push(new Date(year, month, d));
-  }
-  let nextDay = 1;
-  while (cells.length % 7 !== 0) {
-    cells.push(new Date(year, month + 1, nextDay++));
-  }
-
-  return cells;
-}
-
-function isSameMonth(a: Date, b: Date): boolean {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
-}
-
-function formatHeader(viewDate: Date): string {
-  const yy = String(viewDate.getFullYear()).slice(2);
-  const mm = String(viewDate.getMonth() + 1).padStart(2, "0");
-  const dd = String(viewDate.getDate()).padStart(2, "0");
-  const day = DAY_KO[viewDate.getDay()];
-  return `${yy}.${mm}.${dd} (${day})`;
-}
-
-function isSameDay(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
+  return Array.from({ length: totalCells }, (_, index) =>
+    start.add({ days: index }),
   );
 }
 
+function isSameMonth(a: Temporal.PlainDate, b: Temporal.PlainDate): boolean {
+  return a.year === b.year && a.month === b.month;
+}
+
+function formatHeader(viewDate: Temporal.PlainDate): string {
+  const yy = String(viewDate.year).slice(2);
+  const mm = String(viewDate.month).padStart(2, "0");
+  const dd = String(viewDate.day).padStart(2, "0");
+  const day = DAY_KO[viewDate.dayOfWeek % 7];
+  return `${yy}.${mm}.${dd} (${day})`;
+}
+
 export function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
-  const [viewDate, setViewDate] = useState(selectedDate ?? new Date());
+  const [viewDate, setViewDate] = useState(selectedDate ?? todayKst());
 
   const cells = buildCalendarGrid(viewDate);
 
   const prevMonth = () =>
-    setViewDate((d) => new Date(d.getFullYear(), d.getMonth() - 1, 1));
+    setViewDate((d) => d.subtract({ months: 1 }).with({ day: 1 }));
   const nextMonth = () =>
-    setViewDate((d) => new Date(d.getFullYear(), d.getMonth() + 1, 1));
+    setViewDate((d) => d.add({ months: 1 }).with({ day: 1 }));
 
   return (
     <div className="flex flex-col items-center gap-3">
@@ -79,13 +61,13 @@ export function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
         <button
           type="button"
           onClick={() => {
-            const today = new Date();
+            const today = todayKst();
             setViewDate(today);
             onDateSelect?.(today);
           }}
           className="text-main-text text-text-4 cursor-pointer"
         >
-          {formatHeader(new Date())}
+          {formatHeader(todayKst())}
         </button>
         <button
           type="button"
@@ -110,11 +92,11 @@ export function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
       <div className="grid grid-cols-7 gap-x-1.5 gap-y-3">
         {cells.map((date) => {
           const isCurrentMonth = isSameMonth(date, viewDate);
-          const isSelected = selectedDate && isSameDay(selectedDate, date);
+          const isSelected = selectedDate && selectedDate.equals(date);
 
           return (
             <button
-              key={date.toISOString()}
+              key={date.toString()}
               type="button"
               onClick={() => {
                 if (!isCurrentMonth) setViewDate(date);
@@ -128,7 +110,7 @@ export function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
                     : "bg-background-surface text-sub-2"
               }`}
             >
-              {date.getDate()}
+              {date.day}
             </button>
           );
         })}

--- a/src/widgets/header/ui/clock.tsx
+++ b/src/widgets/header/ui/clock.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { nowKst } from "@/shared/lib/kst";
 
 function pad(n: number) {
   return String(n).padStart(2, "0");
@@ -13,14 +14,10 @@ export function Clock() {
 
   useEffect(() => {
     const tick = () => {
-      const now = new Date();
-      setTime(
-        `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`,
-      );
-      setDate(
-        `${String(now.getFullYear()).slice(2)}.${pad(now.getMonth() + 1)}.${pad(now.getDate())}`,
-      );
-      timerRef.current = setTimeout(tick, 1000 - now.getMilliseconds());
+      const now = nowKst();
+      setTime(`${pad(now.hour)}:${pad(now.minute)}:${pad(now.second)}`);
+      setDate(`${String(now.year).slice(2)}.${pad(now.month)}.${pad(now.day)}`);
+      timerRef.current = setTimeout(tick, 1000 - now.millisecond);
     };
     tick();
     return () => clearTimeout(timerRef.current);

--- a/src/widgets/main/ui/MealCard.tsx
+++ b/src/widgets/main/ui/MealCard.tsx
@@ -119,10 +119,11 @@ const MealCard = () => {
     initialMealSelection.mealType,
   );
 
-  const currentDate = todayKst().add({ days: offset });
+  const today = todayKst();
+  const currentDate = today.add({ days: offset });
 
   const debouncedOffset = useDebouncedValue(offset, 300);
-  const debouncedDate = todayKst().add({ days: debouncedOffset });
+  const debouncedDate = today.add({ days: debouncedOffset });
   const dateStr = formatDateParam(debouncedDate);
 
   return (

--- a/src/widgets/main/ui/MealCard.tsx
+++ b/src/widgets/main/ui/MealCard.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/shared/ui/QueryErrorBoundary";
 import { Skeleton } from "@/shared/ui/Skeleton";
 import { formatDateParam, formatDisplayDate } from "@/shared/lib/date";
+import { todayKst } from "@/shared/lib/kst";
 import { useDebouncedValue } from "@/shared/lib/useDebouncedValue";
 
 function MealCardLoading() {
@@ -118,12 +119,10 @@ const MealCard = () => {
     initialMealSelection.mealType,
   );
 
-  const currentDate = new Date();
-  currentDate.setDate(currentDate.getDate() + offset);
+  const currentDate = todayKst().add({ days: offset });
 
   const debouncedOffset = useDebouncedValue(offset, 300);
-  const debouncedDate = new Date();
-  debouncedDate.setDate(debouncedDate.getDate() + debouncedOffset);
+  const debouncedDate = todayKst().add({ days: debouncedOffset });
   const dateStr = formatDateParam(debouncedDate);
 
   return (

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -159,10 +159,11 @@ function TimeTableCardContent({
 const TimeTableCard = () => {
   const [offset, setOffset] = useState(0);
 
-  const currentDate = todayKst().add({ days: offset });
+  const today = todayKst();
+  const currentDate = today.add({ days: offset });
 
   const debouncedOffset = useDebouncedValue(offset, 300);
-  const debouncedDate = todayKst().add({ days: debouncedOffset });
+  const debouncedDate = today.add({ days: debouncedOffset });
   const dateStr = formatDateParam(debouncedDate);
 
   const currentPeriod = debouncedOffset === 0 ? getCurrentPeriod() : null;

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/shared/ui/QueryErrorBoundary";
 import { Skeleton } from "@/shared/ui/Skeleton";
 import { formatDateParam, formatDisplayDate } from "@/shared/lib/date";
+import { todayKst } from "@/shared/lib/kst";
 import { useDebouncedValue } from "@/shared/lib/useDebouncedValue";
 
 function TimeTableCardLoading() {
@@ -158,12 +159,10 @@ function TimeTableCardContent({
 const TimeTableCard = () => {
   const [offset, setOffset] = useState(0);
 
-  const currentDate = new Date();
-  currentDate.setDate(currentDate.getDate() + offset);
+  const currentDate = todayKst().add({ days: offset });
 
   const debouncedOffset = useDebouncedValue(offset, 300);
-  const debouncedDate = new Date();
-  debouncedDate.setDate(debouncedDate.getDate() + debouncedOffset);
+  const debouncedDate = todayKst().add({ days: debouncedOffset });
   const dateStr = formatDateParam(debouncedDate);
 
   const currentPeriod = debouncedOffset === 0 ? getCurrentPeriod() : null;


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- `temporal-polyfill` 도입 및 `app/layout.tsx`에 전역 주입으로 Safari iOS 등 Temporal 미지원 환경 대응
- `src/shared/lib/kst.ts` 신설: `nowKst()`, `todayKst()`, `parseKstWallClock()`, `minutesOfDay()` 등 KST 고정 유틸 제공
- 급식 종류 판정(`getCurrentMealType`), 현재 교시(`getCurrentPeriod`), 홈베이스 예약 게이팅(`isPeriodStarted`) 등 현재시각 계산을 `new Date()` 로컬 getter에서 KST Temporal로 전환
- `Calendar` 컴포넌트 props를 `Temporal.PlainDate`로 전환, 기상음악 날짜 초기화의 KST/로컬 프레임 혼용 버그 수정
- `formatDateParam`, `formatDisplayDate` 포맷터를 Temporal 입력으로 재작성해 SSR(UTC)과 클라이언트 간 hydration 불일치 방지
- 동아리 신청자 제출시각 파싱을 `parseKstWallClock`으로 교체해 비표준 마이크로초 문자열 및 로컬 TZ 파싱 오류 방지

### 타임존 변경 테스트(Sanfransisco/Korea)

**변경 전**
<img width="1137" height="1013" alt="image" src="https://github.com/user-attachments/assets/02efa942-2a83-46e8-a930-5448eda1323f" />

**변경 후**
<img width="1146" height="1020" alt="image" src="https://github.com/user-attachments/assets/29cb7b5b-17e2-497e-aa01-6dd9bf9b2b3f" />

### Safari iOS 환경 테스트

<img width="1337" height="943" alt="image" src="https://github.com/user-attachments/assets/d16b76b3-7fac-4df4-898a-2625f15ffd57" />

## 💬리뷰 요구사항

- [x] `temporal-polyfill@0.3.2`가 SSR(Node)과 클라이언트 양쪽에서 정상 동작하는지 확인 요망 (MDN compat 기준 Safari iOS 미지원으로 폴리필 필수)
- [ ] `Calendar` props 타입이 `Date → Temporal.PlainDate`로 변경됨에 따라 외부에서 직접 `Date`를 넘기는 사용처가 있는지 확인 요망