### PR TITLE
change: 모바일 반응형 및 UX 개선

### DIFF
--- a/app/(main)/dormitory/page.tsx
+++ b/app/(main)/dormitory/page.tsx
@@ -1,13 +1,21 @@
 import { SelfStudySection } from "@/features/self-study/ui/SelfStudySection";
 import { MassageChairSection } from "@/features/massage-chair/ui/MassageChairSection";
 import { WakeUpMusicSection } from "@/features/wake-up-music/ui/WakeUpMusicSection";
+import { HashScroller } from "@/shared/ui/HashScroller";
 
 export default function DormitoryPage() {
   return (
     <main className="flex flex-1 flex-col gap-4 overflow-y-auto px-5 pb-25 sm:gap-6 sm:px-8 lg:px-10 2xl:px-18">
-      <SelfStudySection />
-      <MassageChairSection />
-      <WakeUpMusicSection className="h-auto! flex-1" />
+      <HashScroller />
+      <section id="self-study" className="scroll-mt-4">
+        <SelfStudySection />
+      </section>
+      <section id="massage" className="scroll-mt-4">
+        <MassageChairSection />
+      </section>
+      <section id="wake-up-music" className="flex flex-1 scroll-mt-4">
+        <WakeUpMusicSection className="h-auto! flex-1" />
+      </section>
     </main>
   );
 }

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -5,6 +5,8 @@ import { SidebarDrawer } from "@/widgets/sidebar/ui/sidebarDrawer";
 import { useSidebarDrawer } from "@/widgets/sidebar/model/useSidebarDrawer";
 import { Header } from "@/widgets/header/ui/header";
 import { AiChatButton } from "@/features/ai-chat/ui/AiChatButton";
+import { AiChatModal } from "@/features/ai-chat/ui/AiChatModal";
+import { useAiChatPanel } from "@/features/ai-chat/model/useAiChatPanel";
 
 export default function MainLayout({
   children,
@@ -12,6 +14,7 @@ export default function MainLayout({
   children: React.ReactNode;
 }) {
   const { isOpen, open, close } = useSidebarDrawer();
+  const chat = useAiChatPanel();
 
   return (
     <div className="bg-background flex h-dvh overflow-hidden">
@@ -20,10 +23,13 @@ export default function MainLayout({
       </div>
       <div className="flex flex-1 flex-col overflow-hidden">
         <Header onMenuClick={open} />
-        {children}
+        <div className="relative flex flex-1 flex-col overflow-hidden">
+          {children}
+          <AiChatModal open={chat.isOpen} onClose={chat.close} />
+        </div>
       </div>
       <SidebarDrawer isOpen={isOpen} onClose={close} />
-      <AiChatButton />
+      {!chat.isOpen && <AiChatButton onClick={chat.open} />}
     </div>
   );
 }

--- a/src/features/ai-chat/model/useAiChatPanel.ts
+++ b/src/features/ai-chat/model/useAiChatPanel.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export function useAiChatPanel() {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsOpen(false);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  const open = () => setIsOpen(true);
+  const close = () => setIsOpen(false);
+
+  return { isOpen, open, close };
+}

--- a/src/features/ai-chat/ui/AiChatButton.tsx
+++ b/src/features/ai-chat/ui/AiChatButton.tsx
@@ -1,33 +1,32 @@
 "use client";
 
 import { useState } from "react";
-import { AiChatModal } from "@/features/ai-chat/ui/AiChatModal";
 import Chatbot from "@/shared/asset/svg/Chatbot";
 
-export function AiChatButton() {
-  const [isOpen, setIsOpen] = useState(false);
+interface AiChatButtonProps {
+  onClick: () => void;
+}
+
+export function AiChatButton({ onClick }: AiChatButtonProps) {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <>
-      <button
-        type="button"
-        className="fixed right-6 bottom-6 z-40 flex h-13 w-13 cursor-pointer items-center justify-center overflow-hidden rounded-full border-0 bg-transparent p-0 shadow-[0_4px_16px_rgba(0,0,0,0.16)]"
-        onClick={() => setIsOpen(true)}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
-        {isHovered && (
-          <div className="pointer-events-none absolute right-0 bottom-full mb-4">
-            <div className="bg-background-surface text-sub-1 relative rounded-lg px-4 py-2 text-sm font-medium whitespace-nowrap shadow-[0_0_24px_rgba(0,0,0,0.1)]">
-              AI 챗봇에게 무엇이든 물어보세요!
-              <div className="bg-background-surface absolute right-[22px] -bottom-1.5 h-3 w-3 rotate-45" />
-            </div>
+    <button
+      type="button"
+      className="fixed right-6 bottom-6 z-40 flex h-13 w-13 cursor-pointer items-center justify-center overflow-hidden rounded-full border-0 bg-transparent p-0 shadow-[0_4px_16px_rgba(0,0,0,0.16)]"
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {isHovered && (
+        <div className="pointer-events-none absolute right-0 bottom-full mb-4">
+          <div className="bg-background-surface text-sub-1 relative rounded-lg px-4 py-2 text-sm font-medium whitespace-nowrap shadow-[0_0_24px_rgba(0,0,0,0.1)]">
+            AI 챗봇에게 무엇이든 물어보세요!
+            <div className="bg-background-surface absolute right-[22px] -bottom-1.5 h-3 w-3 rotate-45" />
           </div>
-        )}
-        <Chatbot />
-      </button>
-      <AiChatModal open={isOpen} onClose={() => setIsOpen(false)} />
-    </>
+        </div>
+      )}
+      <Chatbot />
+    </button>
   );
 }

--- a/src/features/ai-chat/ui/AiChatModal.tsx
+++ b/src/features/ai-chat/ui/AiChatModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import Back from "@/shared/asset/svg/Back";
 import Cancel from "@/shared/asset/svg/Cancel";
 import SendArrow from "@/shared/asset/svg/SendArrow";
 import SmallStar from "@/shared/asset/svg/SmallStar";
@@ -65,19 +66,33 @@ export function AiChatModal({ open, onClose }: AiChatModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end justify-end p-6"
+      className="absolute inset-0 z-50 sm:fixed sm:flex sm:items-end sm:justify-end sm:p-6"
       onClick={onClose}
     >
       <div
-        className="bg-background-surface flex h-[560px] w-[400px] flex-col rounded-2xl shadow-[0_0_24px_rgba(0,0,0,0.12)]"
+        className="bg-background-surface flex h-full w-full flex-col sm:h-[560px] sm:w-[400px] sm:rounded-2xl sm:shadow-[0_0_24px_rgba(0,0,0,0.12)]"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="border-sub-4 flex items-center justify-between border-b px-5 py-4">
+        <div className="border-sub-4 flex items-center gap-1 px-5 py-4 sm:justify-between sm:border-b">
+          <button
+            type="button"
+            onClick={onClose}
+            className="cursor-pointer sm:hidden"
+            aria-label="닫기"
+          >
+            <Back direction="left" />
+          </button>
           <div className="flex items-center gap-1">
-            <SmallStar />
+            <span className="hidden sm:flex">
+              <SmallStar />
+            </span>
             <span className="text-main-text text-text-2">AI 챗봇</span>
           </div>
-          <button onClick={onClose} className="cursor-pointer">
+          <button
+            onClick={onClose}
+            className="hidden cursor-pointer sm:block"
+            aria-label="닫기"
+          >
             <Cancel />
           </button>
         </div>
@@ -121,7 +136,7 @@ export function AiChatModal({ open, onClose }: AiChatModalProps) {
           <div ref={messagesEndRef} />
         </div>
 
-        <div className="border-sub-4 flex items-center justify-center gap-2 border-t px-4 py-3">
+        <div className="border-sub-4 flex items-center justify-center gap-2 px-4 py-3 sm:border-t">
           <textarea
             ref={textareaRef}
             className="border-sub-2 bg-background-surface text-main-text placeholder:text-sub-2 focus:border-sub-1 text-caption-1 caret-p-1 flex-1 resize-none rounded-[8px] border px-4 py-3 outline-none"

--- a/src/features/wake-up-music/ui/MusicRecommendCard.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendCard.tsx
@@ -19,7 +19,7 @@ export default function MusicRecommendCard({
   return (
     <div
       onClick={onChange}
-      className="w-[80vw] max-w-90 shrink-0 cursor-pointer sm:w-90"
+      className="w-full shrink-0 cursor-pointer sm:w-[calc((100%-0.75rem)/2)] lg:w-[calc((100%-1.5rem)/3)]"
     >
       <div className="bg-sub-4 relative h-[203px] w-full rounded-xl">
         {thumbnailUrl && (

--- a/src/features/wake-up-music/ui/MusicRecommendCard.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendCard.tsx
@@ -17,8 +17,11 @@ export default function MusicRecommendCard({
   onChange,
 }: MusicRecommendCardProps) {
   return (
-    <div onClick={onChange} className="cursor-pointer">
-      <div className="bg-sub-4 relative h-[203px] w-90 shrink-0 rounded-xl">
+    <div
+      onClick={onChange}
+      className="w-[80vw] max-w-90 shrink-0 cursor-pointer sm:w-90"
+    >
+      <div className="bg-sub-4 relative h-[203px] w-full rounded-xl">
         {thumbnailUrl && (
           <Image
             src={thumbnailUrl}
@@ -33,7 +36,7 @@ export default function MusicRecommendCard({
         </div>
       </div>
 
-      <div>{title}</div>
+      <div className="text-text-3 text-main-text mt-2 truncate">{title}</div>
     </div>
   );
 }

--- a/src/features/wake-up-music/ui/MusicRecommendModal.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendModal.tsx
@@ -17,7 +17,7 @@ interface MusicRecommendModalProps {
 
 function MusicRecommendCardSkeleton() {
   return (
-    <div className="w-[80vw] max-w-90 shrink-0 sm:w-90">
+    <div className="w-full shrink-0 sm:w-[calc((100%-0.75rem)/2)] lg:w-[calc((100%-1.5rem)/3)]">
       <Skeleton className="h-[203px] w-full rounded-xl" />
       <Skeleton className="mt-2 h-5 w-4/5" />
     </div>
@@ -39,7 +39,7 @@ function MusicRecommendEmpty({ reason }: MusicRecommendEmptyProps) {
       : "다시 시도 버튼으로 새 추천을 요청해주세요.";
 
   return (
-    <div className="border-sub-3 bg-background flex min-h-[230px] w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed">
+    <div className="border-sub-3 bg-background flex min-h-[230px] w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed p-4">
       <SmallStar />
       <p className="text-text-2 text-main-text">{message}</p>
       <p className="text-text-3 text-sub-1">{description}</p>
@@ -104,7 +104,7 @@ export function MusicRecommendModal({
           </NoteText>
         </div>
 
-        <div className="flex min-h-[230px] gap-3 overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)] [-webkit-mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
+        <div className="flex min-h-[230px] gap-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {isPending ? (
             Array.from({ length: 3 }).map((_, i) => (
               <MusicRecommendCardSkeleton key={i} />

--- a/src/features/wake-up-music/ui/MusicRecommendModal.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendModal.tsx
@@ -17,7 +17,7 @@ interface MusicRecommendModalProps {
 
 function MusicRecommendCardSkeleton() {
   return (
-    <div className="w-90 shrink-0">
+    <div className="w-[80vw] max-w-90 shrink-0 sm:w-90">
       <Skeleton className="h-[203px] w-full rounded-xl" />
       <Skeleton className="mt-2 h-5 w-4/5" />
     </div>
@@ -104,7 +104,7 @@ export function MusicRecommendModal({
           </NoteText>
         </div>
 
-        <div className="flex min-h-[230px] gap-3 overflow-x-auto">
+        <div className="flex min-h-[230px] gap-3 overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)] [-webkit-mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
           {isPending ? (
             Array.from({ length: 3 }).map((_, i) => (
               <MusicRecommendCardSkeleton key={i} />

--- a/src/shared/ui/HashScroller.tsx
+++ b/src/shared/ui/HashScroller.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+
+const RETRY_DELAYS = [0, 200, 500, 900];
+
+/**
+ * URL 해시(#id)에 해당하는 요소로 스크롤한다.
+ * 대상 섹션이 비동기(Suspense)로 로드되며 높이가 변하므로,
+ * 여러 시점에 재시도해 최종 위치가 어긋나지 않게 한다.
+ */
+export function HashScroller() {
+  useEffect(() => {
+    const { hash } = window.location;
+    if (!hash) return;
+
+    const id = decodeURIComponent(hash.slice(1));
+    const scrollToTarget = () => {
+      document
+        .getElementById(id)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    };
+
+    const timers = RETRY_DELAYS.map((delay) =>
+      window.setTimeout(scrollToTarget, delay),
+    );
+
+    return () => timers.forEach((timer) => window.clearTimeout(timer));
+  }, []);
+
+  return null;
+}

--- a/src/widgets/main/ui/MassageApplyCard.tsx
+++ b/src/widgets/main/ui/MassageApplyCard.tsx
@@ -69,7 +69,7 @@ export default function MassageApplyCard() {
           ? "fit"
           : "small"
       }
-      detailHref="/dormitory"
+      detailHref="/dormitory#massage"
       femaleNotice
       disabled={massageActionState.isActionDisabled}
       onApply={hasAppliedMassage ? handleCancelMassage : handleApplyMassage}

--- a/src/widgets/main/ui/StudyApplyCard.tsx
+++ b/src/widgets/main/ui/StudyApplyCard.tsx
@@ -74,7 +74,7 @@ export default function StudyApplyCard() {
           ? "fit"
           : "small"
       }
-      detailHref="/dormitory"
+      detailHref="/dormitory#self-study"
       disabled={studyActionState.isActionDisabled}
       onApply={hasAppliedStudy ? handleCancelStudy : handleApplyStudy}
     />

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -125,11 +125,11 @@ function TimeTableCardContent({
             <div
               key={it.period}
               ref={active ? activeRef : undefined}
-              className={`bg-sub-4 flex items-center justify-between rounded-lg px-6 py-4 ${
+              className={`bg-sub-4 flex items-center gap-3 rounded-lg px-6 py-4 ${
                 active ? "border-p-1 border" : ""
               }`}
             >
-              <div className="flex items-center gap-1">
+              <div className="flex shrink-0 items-center gap-1">
                 <span className="text-sub-1 text-text-3 font-medium">
                   {it.period} 교시
                 </span>
@@ -139,9 +139,11 @@ function TimeTableCardContent({
                   </span>
                 )}
               </div>
-              <div className="text-sub-1 text-text-4 flex items-center gap-1 font-medium">
-                <span>{it.subject}</span>
-                <span className="text-caption-1 text-sub-2 font-medium">
+              <div className="text-sub-1 text-text-4 flex min-w-0 flex-1 items-center gap-1 font-medium">
+                <span className="min-w-0 flex-1 overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-1.5rem),transparent)] whitespace-nowrap [-webkit-mask-image:linear-gradient(to_right,black_calc(100%-1.5rem),transparent)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                  {it.subject}
+                </span>
+                <span className="text-caption-1 text-sub-2 max-w-24 shrink-0 truncate font-medium">
                   {it.teacher}
                 </span>
               </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

#102

## 📝작업 내용

- AI 챗봇 열림 상태를 `useAiChatPanel` 훅으로 분리하고, 모바일에서 챗봇을 전체 화면 레이아웃으로 대응
- 노래 추천 카드를 반응형 그리드(모바일 1열·sm 2열·lg 3열)로 처리하고 가로 스크롤바 숨김 및 빈 상태 패딩 보정
- 시간표 셀 과목명을 한 줄로 처리하고 마스크 그라데이션 · 교사명 truncate로 가독성 개선
- 안마의자·자습 전체보기 진입 시 해당 섹션으로 스크롤되도록 `HashScroller` 추가 및 상세 링크에 해시 적용

### AI 챗봇 전체 화면

<img width="640" height="1334" alt="image" src="https://github.com/user-attachments/assets/0275f4c0-8781-4a36-a5c0-5d2dd3adc7eb" />

### 시간표 과목 가독성 개선

<img width="640" height="1334" alt="image" src="https://github.com/user-attachments/assets/0402c880-ba78-41ec-b299-e37f8f0bf603" />
