### PR TITLE
v2026.0529.1043

### DIFF
--- a/app/(main)/dormitory/page.tsx
+++ b/app/(main)/dormitory/page.tsx
@@ -1,13 +1,21 @@
 import { SelfStudySection } from "@/features/self-study/ui/SelfStudySection";
 import { MassageChairSection } from "@/features/massage-chair/ui/MassageChairSection";
 import { WakeUpMusicSection } from "@/features/wake-up-music/ui/WakeUpMusicSection";
+import { HashScroller } from "@/shared/ui/HashScroller";
 
 export default function DormitoryPage() {
   return (
     <main className="flex flex-1 flex-col gap-4 overflow-y-auto px-5 pb-25 sm:gap-6 sm:px-8 lg:px-10 2xl:px-18">
-      <SelfStudySection />
-      <MassageChairSection />
-      <WakeUpMusicSection className="h-auto! flex-1" />
+      <HashScroller />
+      <section id="self-study" className="scroll-mt-4">
+        <SelfStudySection />
+      </section>
+      <section id="massage" className="scroll-mt-4">
+        <MassageChairSection />
+      </section>
+      <section id="wake-up-music" className="flex flex-1 scroll-mt-4">
+        <WakeUpMusicSection className="h-auto! flex-1" />
+      </section>
     </main>
   );
 }

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -5,6 +5,8 @@ import { SidebarDrawer } from "@/widgets/sidebar/ui/sidebarDrawer";
 import { useSidebarDrawer } from "@/widgets/sidebar/model/useSidebarDrawer";
 import { Header } from "@/widgets/header/ui/header";
 import { AiChatButton } from "@/features/ai-chat/ui/AiChatButton";
+import { AiChatModal } from "@/features/ai-chat/ui/AiChatModal";
+import { useAiChatPanel } from "@/features/ai-chat/model/useAiChatPanel";
 
 export default function MainLayout({
   children,
@@ -12,6 +14,7 @@ export default function MainLayout({
   children: React.ReactNode;
 }) {
   const { isOpen, open, close } = useSidebarDrawer();
+  const chat = useAiChatPanel();
 
   return (
     <div className="bg-background flex h-dvh overflow-hidden">
@@ -20,10 +23,13 @@ export default function MainLayout({
       </div>
       <div className="flex flex-1 flex-col overflow-hidden">
         <Header onMenuClick={open} />
-        {children}
+        <div className="relative flex flex-1 flex-col overflow-hidden">
+          {children}
+          <AiChatModal open={chat.isOpen} onClose={chat.close} />
+        </div>
       </div>
       <SidebarDrawer isOpen={isOpen} onClose={close} />
-      <AiChatButton />
+      {!chat.isOpen && <AiChatButton onClick={chat.open} />}
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import "temporal-polyfill/global";
 import type { Metadata } from "next";
 import "@sun-typeface/suit/fonts/variable/woff2/SUIT-Variable.css";
 import "./globals.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "19.2.3",
         "react-dropzone": "^15.0.0",
         "sonner": "^2.0.7",
+        "temporal-polyfill": "^0.3.2",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -8393,6 +8394,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.1"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
     },
     "node_modules/terser": {
       "version": "5.48.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "19.2.3",
     "react-dropzone": "^15.0.0",
     "sonner": "^2.0.7",
+    "temporal-polyfill": "^0.3.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/entities/neis/lib/getCurrentMealType.ts
+++ b/src/entities/neis/lib/getCurrentMealType.ts
@@ -2,6 +2,7 @@ import {
   MEAL_TYPE_END_MINUTES,
   type MealType,
 } from "@/entities/neis/model/neis";
+import { minutesOfDay, nowKst } from "@/shared/lib/kst";
 
 interface CurrentMealSelection {
   mealType: MealType;
@@ -9,9 +10,9 @@ interface CurrentMealSelection {
 }
 
 export function getCurrentMealSelection(
-  now = new Date(),
+  now: Temporal.PlainDateTime = nowKst(),
 ): CurrentMealSelection {
-  const totalMinutes = now.getHours() * 60 + now.getMinutes();
+  const totalMinutes = minutesOfDay(now);
 
   if (totalMinutes <= MEAL_TYPE_END_MINUTES.조식) {
     return { mealType: "조식", dateOffset: 0 };

--- a/src/entities/neis/lib/getCurrentPeriod.ts
+++ b/src/entities/neis/lib/getCurrentPeriod.ts
@@ -1,8 +1,9 @@
 import { PERIOD_TIMES } from "@/entities/neis/model/neis";
+import { nowKst } from "@/shared/lib/kst";
 
 export function getCurrentPeriod(): number | null {
-  const now = new Date();
-  const hhmm = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  const now = nowKst();
+  const hhmm = `${String(now.hour).padStart(2, "0")}:${String(now.minute).padStart(2, "0")}`;
   for (const [period, [start, end]] of Object.entries(PERIOD_TIMES)) {
     if (hhmm >= start && hhmm <= end) return Number(period);
   }

--- a/src/features/ai-chat/model/useAiChatPanel.ts
+++ b/src/features/ai-chat/model/useAiChatPanel.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export function useAiChatPanel() {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsOpen(false);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  const open = () => setIsOpen(true);
+  const close = () => setIsOpen(false);
+
+  return { isOpen, open, close };
+}

--- a/src/features/ai-chat/ui/AiChatButton.tsx
+++ b/src/features/ai-chat/ui/AiChatButton.tsx
@@ -1,33 +1,32 @@
 "use client";
 
 import { useState } from "react";
-import { AiChatModal } from "@/features/ai-chat/ui/AiChatModal";
 import Chatbot from "@/shared/asset/svg/Chatbot";
 
-export function AiChatButton() {
-  const [isOpen, setIsOpen] = useState(false);
+interface AiChatButtonProps {
+  onClick: () => void;
+}
+
+export function AiChatButton({ onClick }: AiChatButtonProps) {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <>
-      <button
-        type="button"
-        className="fixed right-6 bottom-6 z-40 flex h-13 w-13 cursor-pointer items-center justify-center overflow-hidden rounded-full border-0 bg-transparent p-0 shadow-[0_4px_16px_rgba(0,0,0,0.16)]"
-        onClick={() => setIsOpen(true)}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
-        {isHovered && (
-          <div className="pointer-events-none absolute right-0 bottom-full mb-4">
-            <div className="bg-background-surface text-sub-1 relative rounded-lg px-4 py-2 text-sm font-medium whitespace-nowrap shadow-[0_0_24px_rgba(0,0,0,0.1)]">
-              AI 챗봇에게 무엇이든 물어보세요!
-              <div className="bg-background-surface absolute right-[22px] -bottom-1.5 h-3 w-3 rotate-45" />
-            </div>
+    <button
+      type="button"
+      className="fixed right-6 bottom-6 z-40 flex h-13 w-13 cursor-pointer items-center justify-center overflow-hidden rounded-full border-0 bg-transparent p-0 shadow-[0_4px_16px_rgba(0,0,0,0.16)]"
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {isHovered && (
+        <div className="pointer-events-none absolute right-0 bottom-full mb-4">
+          <div className="bg-background-surface text-sub-1 relative rounded-lg px-4 py-2 text-sm font-medium whitespace-nowrap shadow-[0_0_24px_rgba(0,0,0,0.1)]">
+            AI 챗봇에게 무엇이든 물어보세요!
+            <div className="bg-background-surface absolute right-[22px] -bottom-1.5 h-3 w-3 rotate-45" />
           </div>
-        )}
-        <Chatbot />
-      </button>
-      <AiChatModal open={isOpen} onClose={() => setIsOpen(false)} />
-    </>
+        </div>
+      )}
+      <Chatbot />
+    </button>
   );
 }

--- a/src/features/ai-chat/ui/AiChatModal.tsx
+++ b/src/features/ai-chat/ui/AiChatModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import Back from "@/shared/asset/svg/Back";
 import Cancel from "@/shared/asset/svg/Cancel";
 import SendArrow from "@/shared/asset/svg/SendArrow";
 import SmallStar from "@/shared/asset/svg/SmallStar";
@@ -65,19 +66,33 @@ export function AiChatModal({ open, onClose }: AiChatModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end justify-end p-6"
+      className="absolute inset-0 z-50 sm:fixed sm:flex sm:items-end sm:justify-end sm:p-6"
       onClick={onClose}
     >
       <div
-        className="bg-background-surface flex h-[560px] w-[400px] flex-col rounded-2xl shadow-[0_0_24px_rgba(0,0,0,0.12)]"
+        className="bg-background-surface flex h-full w-full flex-col sm:h-[560px] sm:w-[400px] sm:rounded-2xl sm:shadow-[0_0_24px_rgba(0,0,0,0.12)]"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="border-sub-4 flex items-center justify-between border-b px-5 py-4">
+        <div className="border-sub-4 flex items-center gap-1 px-5 py-4 sm:justify-between sm:border-b">
+          <button
+            type="button"
+            onClick={onClose}
+            className="cursor-pointer sm:hidden"
+            aria-label="닫기"
+          >
+            <Back direction="left" />
+          </button>
           <div className="flex items-center gap-1">
-            <SmallStar />
+            <span className="hidden sm:flex">
+              <SmallStar />
+            </span>
             <span className="text-main-text text-text-2">AI 챗봇</span>
           </div>
-          <button onClick={onClose} className="cursor-pointer">
+          <button
+            onClick={onClose}
+            className="hidden cursor-pointer sm:block"
+            aria-label="닫기"
+          >
             <Cancel />
           </button>
         </div>
@@ -121,7 +136,7 @@ export function AiChatModal({ open, onClose }: AiChatModalProps) {
           <div ref={messagesEndRef} />
         </div>
 
-        <div className="border-sub-4 flex items-center justify-center gap-2 border-t px-4 py-3">
+        <div className="border-sub-4 flex items-center justify-center gap-2 px-4 py-3 sm:border-t">
           <textarea
             ref={textareaRef}
             className="border-sub-2 bg-background-surface text-main-text placeholder:text-sub-2 focus:border-sub-1 text-caption-1 caret-p-1 flex-1 resize-none rounded-[8px] border px-4 py-3 outline-none"

--- a/src/features/club-application/ui/ClubApplicationListSection.tsx
+++ b/src/features/club-application/ui/ClubApplicationListSection.tsx
@@ -10,6 +10,7 @@ import { userQueries } from "@/entities/user/api/userQueries";
 import { createClubPermission } from "@/entities/club/lib/permission";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 import { formatDateParam } from "@/shared/lib/date";
+import { parseKstWallClock } from "@/shared/lib/kst";
 import {
   ClientQueryBoundary,
   type QueryErrorFallbackProps,
@@ -23,9 +24,9 @@ interface ClubApplicationListSectionProps {
 }
 
 function formatSubmittedAt(value: string): string {
-  const date = new Date(value);
+  const date = parseKstWallClock(value);
 
-  if (Number.isNaN(date.getTime())) {
+  if (!date) {
     return value;
   }
 

--- a/src/features/homebase/lib/isPeriodStarted.ts
+++ b/src/features/homebase/lib/isPeriodStarted.ts
@@ -1,11 +1,9 @@
+import { minutesOfDay, nowKst } from "@/shared/lib/kst";
 import { HOMEBASE_SCHEDULE, PERIODS } from "../model/constants";
 
 function isPastTime(timeStr: string): boolean {
   const [hour, minute] = timeStr.split(":").map(Number);
-  const now = new Date();
-  const target = new Date();
-  target.setHours(hour, minute, 0, 0);
-  return now >= target;
+  return minutesOfDay(nowKst()) >= hour * 60 + minute;
 }
 
 export function isPeriodStarted(period: string): boolean {

--- a/src/features/homebase/model/useHomebaseReservation.ts
+++ b/src/features/homebase/model/useHomebaseReservation.ts
@@ -9,12 +9,13 @@ import { useHomebaseReservationActions } from "@/features/homebase/model/useHome
 import { useHomebaseReservationData } from "@/features/homebase/model/useHomebaseReservationData";
 import { useHomebaseStudentSelection } from "@/features/homebase/model/useHomebaseStudentSelection";
 import { formatDateParam } from "@/shared/lib/date";
+import { todayKst } from "@/shared/lib/kst";
 
 export function useHomebaseReservation() {
   const [selectedFloor, setSelectedFloor] = useState("2F");
   const [selectedTable, setSelectedTable] = useState<string | null>(null);
   const [reason, setReason] = useState("");
-  const [reservationDate] = useState(() => formatDateParam(new Date()));
+  const [reservationDate] = useState(() => formatDateParam(todayKst()));
   const {
     selectedStartPeriod,
     selectedStartNum,

--- a/src/features/wake-up-music/lib/date.ts
+++ b/src/features/wake-up-music/lib/date.ts
@@ -1,18 +1,19 @@
-import { nowKst, todayKst } from "@/shared/lib/kst";
+import { nowKst } from "@/shared/lib/kst";
 
 const WAKE_UP_HOUR = 7;
 const WAKE_UP_MINUTE = 25;
 
 export function getInitialMusicDate(): Temporal.PlainDate {
   const now = nowKst();
+  const today = now.toPlainDate();
 
   const isBeforeWakeUp =
     now.hour < WAKE_UP_HOUR ||
     (now.hour === WAKE_UP_HOUR && now.minute < WAKE_UP_MINUTE);
 
   if (isBeforeWakeUp) {
-    return todayKst().subtract({ days: 1 });
+    return today.subtract({ days: 1 });
   }
 
-  return todayKst();
+  return today;
 }

--- a/src/features/wake-up-music/lib/date.ts
+++ b/src/features/wake-up-music/lib/date.ts
@@ -1,20 +1,18 @@
+import { nowKst, todayKst } from "@/shared/lib/kst";
+
 const WAKE_UP_HOUR = 7;
 const WAKE_UP_MINUTE = 25;
 
-export function getInitialMusicDate(): Date {
-  const now = new Date();
-  const utc = now.getTime() + now.getTimezoneOffset() * 60000;
-  const kst = new Date(utc + 9 * 60 * 60 * 1000);
+export function getInitialMusicDate(): Temporal.PlainDate {
+  const now = nowKst();
 
   const isBeforeWakeUp =
-    kst.getHours() < WAKE_UP_HOUR ||
-    (kst.getHours() === WAKE_UP_HOUR && kst.getMinutes() < WAKE_UP_MINUTE);
+    now.hour < WAKE_UP_HOUR ||
+    (now.hour === WAKE_UP_HOUR && now.minute < WAKE_UP_MINUTE);
 
   if (isBeforeWakeUp) {
-    const yesterday = new Date(now);
-    yesterday.setDate(now.getDate() - 1);
-    return yesterday;
+    return todayKst().subtract({ days: 1 });
   }
 
-  return now;
+  return todayKst();
 }

--- a/src/features/wake-up-music/model/useWakeUpMusic.ts
+++ b/src/features/wake-up-music/model/useWakeUpMusic.ts
@@ -12,18 +12,20 @@ import {
 } from "@/entities/dormitory/api/dormitoryQueries";
 import { userQueries } from "@/entities/user/api/userQueries";
 import { formatDateParam } from "@/shared/lib/date";
+import { todayKst } from "@/shared/lib/kst";
 import { getInitialMusicDate } from "@/features/wake-up-music/lib/date";
 import { musicUrlSchema } from "@/features/wake-up-music/lib/wakeUpMusicSchema";
 
 export function useWakeUpMusic() {
   const queryClient = useQueryClient();
   const [urlInput, setUrlInput] = useState("");
-  const [selectedDate, setSelectedDate] = useState<Date>(getInitialMusicDate);
+  const [selectedDate, setSelectedDate] =
+    useState<Temporal.PlainDate>(getInitialMusicDate);
 
   const canApply = musicUrlSchema.safeParse(urlInput).success;
 
   const selectedDateString = formatDateParam(selectedDate);
-  const isToday = selectedDateString === formatDateParam(new Date());
+  const isToday = selectedDateString === formatDateParam(todayKst());
   const musicQuery = dormitoryQueries.music(selectedDateString);
 
   const { data: songs = [] } = useQuery(musicQuery);

--- a/src/features/wake-up-music/ui/MusicRecommendCard.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendCard.tsx
@@ -19,7 +19,7 @@ export default function MusicRecommendCard({
   return (
     <div
       onClick={onChange}
-      className="w-[80vw] max-w-90 shrink-0 cursor-pointer sm:w-90"
+      className="w-full shrink-0 cursor-pointer sm:w-[calc((100%-0.75rem)/2)] lg:w-[calc((100%-1.5rem)/3)]"
     >
       <div className="bg-sub-4 relative h-[203px] w-full rounded-xl">
         {thumbnailUrl && (

--- a/src/features/wake-up-music/ui/MusicRecommendCard.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendCard.tsx
@@ -17,8 +17,11 @@ export default function MusicRecommendCard({
   onChange,
 }: MusicRecommendCardProps) {
   return (
-    <div onClick={onChange} className="cursor-pointer">
-      <div className="bg-sub-4 relative h-[203px] w-90 shrink-0 rounded-xl">
+    <div
+      onClick={onChange}
+      className="w-[80vw] max-w-90 shrink-0 cursor-pointer sm:w-90"
+    >
+      <div className="bg-sub-4 relative h-[203px] w-full rounded-xl">
         {thumbnailUrl && (
           <Image
             src={thumbnailUrl}
@@ -33,7 +36,7 @@ export default function MusicRecommendCard({
         </div>
       </div>
 
-      <div>{title}</div>
+      <div className="text-text-3 text-main-text mt-2 truncate">{title}</div>
     </div>
   );
 }

--- a/src/features/wake-up-music/ui/MusicRecommendModal.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendModal.tsx
@@ -17,7 +17,7 @@ interface MusicRecommendModalProps {
 
 function MusicRecommendCardSkeleton() {
   return (
-    <div className="w-[80vw] max-w-90 shrink-0 sm:w-90">
+    <div className="w-full shrink-0 sm:w-[calc((100%-0.75rem)/2)] lg:w-[calc((100%-1.5rem)/3)]">
       <Skeleton className="h-[203px] w-full rounded-xl" />
       <Skeleton className="mt-2 h-5 w-4/5" />
     </div>
@@ -39,7 +39,7 @@ function MusicRecommendEmpty({ reason }: MusicRecommendEmptyProps) {
       : "다시 시도 버튼으로 새 추천을 요청해주세요.";
 
   return (
-    <div className="border-sub-3 bg-background flex min-h-[230px] w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed">
+    <div className="border-sub-3 bg-background flex min-h-[230px] w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed p-4">
       <SmallStar />
       <p className="text-text-2 text-main-text">{message}</p>
       <p className="text-text-3 text-sub-1">{description}</p>
@@ -104,7 +104,7 @@ export function MusicRecommendModal({
           </NoteText>
         </div>
 
-        <div className="flex min-h-[230px] gap-3 overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)] [-webkit-mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
+        <div className="flex min-h-[230px] gap-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {isPending ? (
             Array.from({ length: 3 }).map((_, i) => (
               <MusicRecommendCardSkeleton key={i} />

--- a/src/features/wake-up-music/ui/MusicRecommendModal.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendModal.tsx
@@ -17,7 +17,7 @@ interface MusicRecommendModalProps {
 
 function MusicRecommendCardSkeleton() {
   return (
-    <div className="w-90 shrink-0">
+    <div className="w-[80vw] max-w-90 shrink-0 sm:w-90">
       <Skeleton className="h-[203px] w-full rounded-xl" />
       <Skeleton className="mt-2 h-5 w-4/5" />
     </div>
@@ -104,7 +104,7 @@ export function MusicRecommendModal({
           </NoteText>
         </div>
 
-        <div className="flex min-h-[230px] gap-3 overflow-x-auto">
+        <div className="flex min-h-[230px] gap-3 overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)] [-webkit-mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
           {isPending ? (
             Array.from({ length: 3 }).map((_, i) => (
               <MusicRecommendCardSkeleton key={i} />

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -3,19 +3,27 @@ interface FormatDateParamOptions {
   minute?: boolean;
 }
 
+type DateLike = Temporal.PlainDate | Temporal.PlainDateTime;
+
+function hasTime(date: DateLike): date is Temporal.PlainDateTime {
+  return "hour" in date;
+}
+
 export function formatDateParam(
-  date: Date,
+  date: DateLike,
   options: FormatDateParamOptions = {},
 ): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+  const year = date.year;
+  const month = String(date.month).padStart(2, "0");
+  const day = String(date.day).padStart(2, "0");
   const formattedDate = `${year}-${month}-${day}`;
 
-  const timeParts = [
-    options.hour && String(date.getHours()).padStart(2, "0"),
-    options.minute && String(date.getMinutes()).padStart(2, "0"),
-  ].filter(Boolean);
+  const timeParts = hasTime(date)
+    ? [
+        options.hour && String(date.hour).padStart(2, "0"),
+        options.minute && String(date.minute).padStart(2, "0"),
+      ].filter(Boolean)
+    : [];
 
   if (timeParts.length === 0) {
     return formattedDate;
@@ -26,10 +34,11 @@ export function formatDateParam(
 
 export const DAYS = ["일", "월", "화", "수", "목", "금", "토"];
 
-export function formatDisplayDate(date: Date): string {
-  const yy = String(date.getFullYear()).slice(2);
-  const mm = String(date.getMonth() + 1).padStart(2, "0");
-  const dd = String(date.getDate()).padStart(2, "0");
-  const day = DAYS[date.getDay()];
+export function formatDisplayDate(date: DateLike): string {
+  const yy = String(date.year).slice(2);
+  const mm = String(date.month).padStart(2, "0");
+  const dd = String(date.day).padStart(2, "0");
+  // Temporal의 dayOfWeek는 1(월)~7(일) → DAYS(0=일)에 맞춰 매핑
+  const day = DAYS[date.dayOfWeek % 7];
   return `${yy}.${mm}.${dd} (${day})`;
 }

--- a/src/shared/lib/kst.ts
+++ b/src/shared/lib/kst.ts
@@ -1,0 +1,36 @@
+const KST_TIME_ZONE = "Asia/Seoul";
+
+/**
+ * 실행 환경(브라우저/SSR Node)의 타임존과 무관하게 KST 벽시계를 반환한다.
+ */
+export function nowKst(): Temporal.PlainDateTime {
+  return Temporal.Now.plainDateTimeISO(KST_TIME_ZONE);
+}
+
+/**
+ * 환경 타임존과 무관한 KST 기준 오늘 날짜를 반환한다.
+ */
+export function todayKst(): Temporal.PlainDate {
+  return Temporal.Now.plainDateISO(KST_TIME_ZONE);
+}
+
+/**
+ * 백엔드가 주는 오프셋 없는 KST 벽시계 문자열을 파싱한다.
+ * 추가 타임존 보정 없이 그대로 KST로 해석하며, 잘못된 값이면 null을 반환한다.
+ */
+export function parseKstWallClock(
+  value: string,
+): Temporal.PlainDateTime | null {
+  try {
+    return Temporal.PlainDateTime.from(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 자정 기준 분(minute) 값으로 변환한다. (시간 구간 비교용)
+ */
+export function minutesOfDay(dateTime: Temporal.PlainDateTime): number {
+  return dateTime.hour * 60 + dateTime.minute;
+}

--- a/src/shared/lib/timeWindow.ts
+++ b/src/shared/lib/timeWindow.ts
@@ -1,3 +1,5 @@
+import { minutesOfDay } from "@/shared/lib/kst";
+
 export interface TimeOfDay {
   hour: number;
   minute: number;
@@ -12,11 +14,11 @@ export function isTimeInWindow({
   start,
   end,
 }: {
-  date: Date;
+  date: Temporal.PlainDateTime;
   start: TimeOfDay;
   end: TimeOfDay;
 }): boolean {
-  const currentMinutes = date.getHours() * 60 + date.getMinutes();
+  const currentMinutes = minutesOfDay(date);
 
   return currentMinutes >= toMinutes(start) && currentMinutes < toMinutes(end);
 }

--- a/src/shared/lib/useCurrentTime.ts
+++ b/src/shared/lib/useCurrentTime.ts
@@ -1,13 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { nowKst } from "@/shared/lib/kst";
 
-export function useCurrentTime(intervalMs = 5_000): Date {
-  const [currentTime, setCurrentTime] = useState(() => new Date());
+export function useCurrentTime(intervalMs = 5_000): Temporal.PlainDateTime {
+  const [currentTime, setCurrentTime] = useState(nowKst);
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
-      setCurrentTime(new Date());
+      setCurrentTime(nowKst());
     }, intervalMs);
 
     return () => window.clearInterval(intervalId);

--- a/src/shared/ui/Calendar.tsx
+++ b/src/shared/ui/Calendar.tsx
@@ -2,69 +2,51 @@
 
 import { useState } from "react";
 import Back from "@/shared/asset/svg/Back";
+import { todayKst } from "@/shared/lib/kst";
 
 interface CalendarProps {
-  selectedDate?: Date;
-  onDateSelect?: (date: Date) => void;
+  selectedDate?: Temporal.PlainDate;
+  onDateSelect?: (date: Temporal.PlainDate) => void;
 }
 
 const DAY_LABELS = ["월", "화", "수", "목", "금", "토", "일"];
 
 const DAY_KO = ["일", "월", "화", "수", "목", "금", "토"];
 
-function buildCalendarGrid(viewDate: Date): Date[] {
-  const year = viewDate.getFullYear();
-  const month = viewDate.getMonth();
-  const firstDay = new Date(year, month, 1).getDay();
-  const offset = firstDay === 0 ? 6 : firstDay - 1;
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
-  const prevMonthDays = new Date(year, month, 0).getDate();
+function buildCalendarGrid(viewDate: Temporal.PlainDate): Temporal.PlainDate[] {
+  const firstOfMonth = viewDate.with({ day: 1 });
+  // dayOfWeek: 1(월)~7(일) → 월요일 시작 그리드 오프셋
+  const offset = firstOfMonth.dayOfWeek - 1;
+  const start = firstOfMonth.subtract({ days: offset });
 
-  const cells: Date[] = [];
+  const totalCells = Math.ceil((offset + viewDate.daysInMonth) / 7) * 7;
 
-  for (let i = offset - 1; i >= 0; i--) {
-    cells.push(new Date(year, month - 1, prevMonthDays - i));
-  }
-  for (let d = 1; d <= daysInMonth; d++) {
-    cells.push(new Date(year, month, d));
-  }
-  let nextDay = 1;
-  while (cells.length % 7 !== 0) {
-    cells.push(new Date(year, month + 1, nextDay++));
-  }
-
-  return cells;
-}
-
-function isSameMonth(a: Date, b: Date): boolean {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
-}
-
-function formatHeader(viewDate: Date): string {
-  const yy = String(viewDate.getFullYear()).slice(2);
-  const mm = String(viewDate.getMonth() + 1).padStart(2, "0");
-  const dd = String(viewDate.getDate()).padStart(2, "0");
-  const day = DAY_KO[viewDate.getDay()];
-  return `${yy}.${mm}.${dd} (${day})`;
-}
-
-function isSameDay(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
+  return Array.from({ length: totalCells }, (_, index) =>
+    start.add({ days: index }),
   );
 }
 
+function isSameMonth(a: Temporal.PlainDate, b: Temporal.PlainDate): boolean {
+  return a.year === b.year && a.month === b.month;
+}
+
+function formatHeader(viewDate: Temporal.PlainDate): string {
+  const yy = String(viewDate.year).slice(2);
+  const mm = String(viewDate.month).padStart(2, "0");
+  const dd = String(viewDate.day).padStart(2, "0");
+  const day = DAY_KO[viewDate.dayOfWeek % 7];
+  return `${yy}.${mm}.${dd} (${day})`;
+}
+
 export function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
-  const [viewDate, setViewDate] = useState(selectedDate ?? new Date());
+  const [viewDate, setViewDate] = useState(selectedDate ?? todayKst());
 
   const cells = buildCalendarGrid(viewDate);
 
   const prevMonth = () =>
-    setViewDate((d) => new Date(d.getFullYear(), d.getMonth() - 1, 1));
+    setViewDate((d) => d.subtract({ months: 1 }).with({ day: 1 }));
   const nextMonth = () =>
-    setViewDate((d) => new Date(d.getFullYear(), d.getMonth() + 1, 1));
+    setViewDate((d) => d.add({ months: 1 }).with({ day: 1 }));
 
   return (
     <div className="flex flex-col items-center gap-3">
@@ -79,13 +61,13 @@ export function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
         <button
           type="button"
           onClick={() => {
-            const today = new Date();
+            const today = todayKst();
             setViewDate(today);
             onDateSelect?.(today);
           }}
           className="text-main-text text-text-4 cursor-pointer"
         >
-          {formatHeader(new Date())}
+          {formatHeader(todayKst())}
         </button>
         <button
           type="button"
@@ -110,11 +92,11 @@ export function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
       <div className="grid grid-cols-7 gap-x-1.5 gap-y-3">
         {cells.map((date) => {
           const isCurrentMonth = isSameMonth(date, viewDate);
-          const isSelected = selectedDate && isSameDay(selectedDate, date);
+          const isSelected = selectedDate && selectedDate.equals(date);
 
           return (
             <button
-              key={date.toISOString()}
+              key={date.toString()}
               type="button"
               onClick={() => {
                 if (!isCurrentMonth) setViewDate(date);
@@ -128,7 +110,7 @@ export function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
                     : "bg-background-surface text-sub-2"
               }`}
             >
-              {date.getDate()}
+              {date.day}
             </button>
           );
         })}

--- a/src/shared/ui/HashScroller.tsx
+++ b/src/shared/ui/HashScroller.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+
+const RETRY_DELAYS = [0, 200, 500, 900];
+
+/**
+ * URL 해시(#id)에 해당하는 요소로 스크롤한다.
+ * 대상 섹션이 비동기(Suspense)로 로드되며 높이가 변하므로,
+ * 여러 시점에 재시도해 최종 위치가 어긋나지 않게 한다.
+ */
+export function HashScroller() {
+  useEffect(() => {
+    const { hash } = window.location;
+    if (!hash) return;
+
+    const id = decodeURIComponent(hash.slice(1));
+    const scrollToTarget = () => {
+      document
+        .getElementById(id)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    };
+
+    const timers = RETRY_DELAYS.map((delay) =>
+      window.setTimeout(scrollToTarget, delay),
+    );
+
+    return () => timers.forEach((timer) => window.clearTimeout(timer));
+  }, []);
+
+  return null;
+}

--- a/src/widgets/header/ui/clock.tsx
+++ b/src/widgets/header/ui/clock.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { nowKst } from "@/shared/lib/kst";
 
 function pad(n: number) {
   return String(n).padStart(2, "0");
@@ -13,14 +14,10 @@ export function Clock() {
 
   useEffect(() => {
     const tick = () => {
-      const now = new Date();
-      setTime(
-        `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`,
-      );
-      setDate(
-        `${String(now.getFullYear()).slice(2)}.${pad(now.getMonth() + 1)}.${pad(now.getDate())}`,
-      );
-      timerRef.current = setTimeout(tick, 1000 - now.getMilliseconds());
+      const now = nowKst();
+      setTime(`${pad(now.hour)}:${pad(now.minute)}:${pad(now.second)}`);
+      setDate(`${String(now.year).slice(2)}.${pad(now.month)}.${pad(now.day)}`);
+      timerRef.current = setTimeout(tick, 1000 - now.millisecond);
     };
     tick();
     return () => clearTimeout(timerRef.current);

--- a/src/widgets/main/ui/MassageApplyCard.tsx
+++ b/src/widgets/main/ui/MassageApplyCard.tsx
@@ -69,7 +69,7 @@ export default function MassageApplyCard() {
           ? "fit"
           : "small"
       }
-      detailHref="/dormitory"
+      detailHref="/dormitory#massage"
       femaleNotice
       disabled={massageActionState.isActionDisabled}
       onApply={hasAppliedMassage ? handleCancelMassage : handleApplyMassage}

--- a/src/widgets/main/ui/MealCard.tsx
+++ b/src/widgets/main/ui/MealCard.tsx
@@ -119,10 +119,11 @@ const MealCard = () => {
     initialMealSelection.mealType,
   );
 
-  const currentDate = todayKst().add({ days: offset });
+  const today = todayKst();
+  const currentDate = today.add({ days: offset });
 
   const debouncedOffset = useDebouncedValue(offset, 300);
-  const debouncedDate = todayKst().add({ days: debouncedOffset });
+  const debouncedDate = today.add({ days: debouncedOffset });
   const dateStr = formatDateParam(debouncedDate);
 
   return (

--- a/src/widgets/main/ui/MealCard.tsx
+++ b/src/widgets/main/ui/MealCard.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/shared/ui/QueryErrorBoundary";
 import { Skeleton } from "@/shared/ui/Skeleton";
 import { formatDateParam, formatDisplayDate } from "@/shared/lib/date";
+import { todayKst } from "@/shared/lib/kst";
 import { useDebouncedValue } from "@/shared/lib/useDebouncedValue";
 
 function MealCardLoading() {
@@ -118,12 +119,10 @@ const MealCard = () => {
     initialMealSelection.mealType,
   );
 
-  const currentDate = new Date();
-  currentDate.setDate(currentDate.getDate() + offset);
+  const currentDate = todayKst().add({ days: offset });
 
   const debouncedOffset = useDebouncedValue(offset, 300);
-  const debouncedDate = new Date();
-  debouncedDate.setDate(debouncedDate.getDate() + debouncedOffset);
+  const debouncedDate = todayKst().add({ days: debouncedOffset });
   const dateStr = formatDateParam(debouncedDate);
 
   return (

--- a/src/widgets/main/ui/StudyApplyCard.tsx
+++ b/src/widgets/main/ui/StudyApplyCard.tsx
@@ -74,7 +74,7 @@ export default function StudyApplyCard() {
           ? "fit"
           : "small"
       }
-      detailHref="/dormitory"
+      detailHref="/dormitory#self-study"
       disabled={studyActionState.isActionDisabled}
       onApply={hasAppliedStudy ? handleCancelStudy : handleApplyStudy}
     />

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -159,10 +159,11 @@ function TimeTableCardContent({
 const TimeTableCard = () => {
   const [offset, setOffset] = useState(0);
 
-  const currentDate = todayKst().add({ days: offset });
+  const today = todayKst();
+  const currentDate = today.add({ days: offset });
 
   const debouncedOffset = useDebouncedValue(offset, 300);
-  const debouncedDate = todayKst().add({ days: debouncedOffset });
+  const debouncedDate = today.add({ days: debouncedOffset });
   const dateStr = formatDateParam(debouncedDate);
 
   const currentPeriod = debouncedOffset === 0 ? getCurrentPeriod() : null;

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/shared/ui/QueryErrorBoundary";
 import { Skeleton } from "@/shared/ui/Skeleton";
 import { formatDateParam, formatDisplayDate } from "@/shared/lib/date";
+import { todayKst } from "@/shared/lib/kst";
 import { useDebouncedValue } from "@/shared/lib/useDebouncedValue";
 
 function TimeTableCardLoading() {
@@ -158,12 +159,10 @@ function TimeTableCardContent({
 const TimeTableCard = () => {
   const [offset, setOffset] = useState(0);
 
-  const currentDate = new Date();
-  currentDate.setDate(currentDate.getDate() + offset);
+  const currentDate = todayKst().add({ days: offset });
 
   const debouncedOffset = useDebouncedValue(offset, 300);
-  const debouncedDate = new Date();
-  debouncedDate.setDate(debouncedDate.getDate() + debouncedOffset);
+  const debouncedDate = todayKst().add({ days: debouncedOffset });
   const dateStr = formatDateParam(debouncedDate);
 
   const currentPeriod = debouncedOffset === 0 ? getCurrentPeriod() : null;

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -125,11 +125,11 @@ function TimeTableCardContent({
             <div
               key={it.period}
               ref={active ? activeRef : undefined}
-              className={`bg-sub-4 flex items-center justify-between rounded-lg px-6 py-4 ${
+              className={`bg-sub-4 flex items-center gap-3 rounded-lg px-6 py-4 ${
                 active ? "border-p-1 border" : ""
               }`}
             >
-              <div className="flex items-center gap-1">
+              <div className="flex shrink-0 items-center gap-1">
                 <span className="text-sub-1 text-text-3 font-medium">
                   {it.period} 교시
                 </span>
@@ -139,9 +139,11 @@ function TimeTableCardContent({
                   </span>
                 )}
               </div>
-              <div className="text-sub-1 text-text-4 flex items-center gap-1 font-medium">
-                <span>{it.subject}</span>
-                <span className="text-caption-1 text-sub-2 font-medium">
+              <div className="text-sub-1 text-text-4 flex min-w-0 flex-1 items-center gap-1 font-medium">
+                <span className="min-w-0 flex-1 overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-1.5rem),transparent)] whitespace-nowrap [-webkit-mask-image:linear-gradient(to_right,black_calc(100%-1.5rem),transparent)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                  {it.subject}
+                </span>
+                <span className="text-caption-1 text-sub-2 max-w-24 shrink-0 truncate font-medium">
                   {it.teacher}
                 </span>
               </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- #144 시간 처리를 KST 기준으로 전환하고, 자정 경계에서 발생하던 날짜 불일치를 방지하기 위해 시각 조회를 단일화했습니다. temporal-polyfill을 도입하여 전역 주입했습니다.
- #145 노래 추천 카드 모바일 반응형 처리 및 레이아웃을 개선했습니다. 시간표 셀 과목명을 한 줄로 처리하고 가독성을 높였습니다. 모바일 챗봇 전체 화면 레이아웃에 대응하고, 안마의자·자습 전체보기 클릭 시 해당 섹션으로 자동 스크롤되도록 변경했습니다.