### PR TITLE
fix: NoteTooltip 반응형 및 버그 수정

### DIFF
--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -62,7 +62,11 @@ export function MassageChairSection() {
         <div className="flex items-center gap-2">
           <Chair />
           <span className="text-main-text text-text-1">안마의자</span>
-          <NoteTooltip notes={MASSAGE_NOTES} ariaLabel="안마의자 안내 보기" className="lg:hidden" />
+          <NoteTooltip
+            notes={MASSAGE_NOTES}
+            ariaLabel="안마의자 안내 보기"
+            className="lg:hidden"
+          />
         </div>
         <div className="flex items-center gap-1">
           <span className="text-sub-1 text-caption-1">신청인</span>

--- a/src/features/massage-chair/ui/MassageChairSection.tsx
+++ b/src/features/massage-chair/ui/MassageChairSection.tsx
@@ -62,7 +62,7 @@ export function MassageChairSection() {
         <div className="flex items-center gap-2">
           <Chair />
           <span className="text-main-text text-text-1">안마의자</span>
-          <NoteTooltip notes={MASSAGE_NOTES} ariaLabel="안마의자 안내 보기" />
+          <NoteTooltip notes={MASSAGE_NOTES} ariaLabel="안마의자 안내 보기" className="lg:hidden" />
         </div>
         <div className="flex items-center gap-1">
           <span className="text-sub-1 text-caption-1">신청인</span>

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -111,7 +111,7 @@ export function SelfStudySection() {
           <div className="flex items-center gap-2">
             <ApplyStudy />
             <span className="text-main-text text-text-1">자습신청</span>
-            <NoteTooltip notes={STUDY_NOTES} ariaLabel="자습신청 안내 보기" />
+            <NoteTooltip notes={STUDY_NOTES} ariaLabel="자습신청 안내 보기" className="lg:hidden" />
           </div>
           <div className="flex items-center gap-1">
             <span className="text-sub-1 text-caption-1">신청인</span>
@@ -145,7 +145,7 @@ export function SelfStudySection() {
       </div>
 
       <div
-        className={`flex flex-col-reverse gap-6 lg:flex-row lg:items-stretch${filteredStudents.length === 0 ? "max-lg:hidden" : ""}`}
+        className={`flex flex-col-reverse gap-6 lg:flex-row lg:items-stretch ${filteredStudents.length === 0 ? "max-lg:hidden" : ""}`}
       >
         <div className="relative min-w-0 flex-1 lg:min-h-0 lg:overflow-hidden">
           <div className="scrollbar-hide flex max-h-125 flex-wrap gap-4 overflow-y-auto lg:absolute lg:inset-0 lg:max-h-none lg:content-start lg:pr-1">

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -111,7 +111,11 @@ export function SelfStudySection() {
           <div className="flex items-center gap-2">
             <ApplyStudy />
             <span className="text-main-text text-text-1">자습신청</span>
-            <NoteTooltip notes={STUDY_NOTES} ariaLabel="자습신청 안내 보기" className="lg:hidden" />
+            <NoteTooltip
+              notes={STUDY_NOTES}
+              ariaLabel="자습신청 안내 보기"
+              className="lg:hidden"
+            />
           </div>
           <div className="flex items-center gap-1">
             <span className="text-sub-1 text-caption-1">신청인</span>

--- a/src/features/self-study/ui/StudyFilterModal.tsx
+++ b/src/features/self-study/ui/StudyFilterModal.tsx
@@ -33,7 +33,7 @@ export function StudyFilterModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-background/50 px-5"
+      className="bg-background/50 fixed inset-0 z-50 flex items-center justify-center px-5"
       onClick={onClose}
     >
       <div

--- a/src/features/self-study/ui/StudyFilterModal.tsx
+++ b/src/features/self-study/ui/StudyFilterModal.tsx
@@ -33,7 +33,7 @@ export function StudyFilterModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-white/30 px-5"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/50 px-5"
       onClick={onClose}
     >
       <div

--- a/src/shared/ui/NoteTooltip.tsx
+++ b/src/shared/ui/NoteTooltip.tsx
@@ -34,7 +34,10 @@ export function NoteTooltip({
   useEffect(() => {
     if (!isOpen) return;
     const handleClose = () => setIsOpen(false);
-    window.addEventListener("scroll", handleClose, { capture: true, passive: true });
+    window.addEventListener("scroll", handleClose, {
+      capture: true,
+      passive: true,
+    });
     window.addEventListener("resize", handleClose);
     return () => {
       window.removeEventListener("scroll", handleClose, { capture: true });

--- a/src/shared/ui/NoteTooltip.tsx
+++ b/src/shared/ui/NoteTooltip.tsx
@@ -34,7 +34,7 @@ export function NoteTooltip({
   useEffect(() => {
     if (!isOpen) return;
     const handleClose = () => setIsOpen(false);
-    window.addEventListener("scroll", handleClose, { capture: true });
+    window.addEventListener("scroll", handleClose, { capture: true, passive: true });
     window.addEventListener("resize", handleClose);
     return () => {
       window.removeEventListener("scroll", handleClose, { capture: true });

--- a/src/shared/ui/NoteTooltip.tsx
+++ b/src/shared/ui/NoteTooltip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createPortal } from "react-dom";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import Exclamation from "@/shared/asset/svg/Exclamation";
 
@@ -10,6 +10,7 @@ type TooltipPlacement = "top" | "bottom";
 interface NoteTooltipProps {
   notes: string[];
   ariaLabel?: string;
+  className?: string;
 }
 
 const arrowPlacementStyles = {
@@ -22,12 +23,24 @@ const TOOLTIP_GAP = 10;
 export function NoteTooltip({
   notes,
   ariaLabel = "안내 보기",
+  className = "sm:hidden",
 }: NoteTooltipProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [placement, setPlacement] = useState<TooltipPlacement>("top");
   const [tooltipStyle, setTooltipStyle] = useState<CSSProperties>({});
   const [arrowLeft, setArrowLeft] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClose = () => setIsOpen(false);
+    window.addEventListener("scroll", handleClose, { capture: true });
+    window.addEventListener("resize", handleClose);
+    return () => {
+      window.removeEventListener("scroll", handleClose, { capture: true });
+      window.removeEventListener("resize", handleClose);
+    };
+  }, [isOpen]);
 
   const handleToggle = () => {
     if (!isOpen && buttonRef.current) {
@@ -58,7 +71,7 @@ export function NoteTooltip({
   };
 
   return (
-    <div className="inline-flex shrink-0 sm:hidden">
+    <div className={`inline-flex shrink-0 ${className}`}>
       <button
         ref={buttonRef}
         type="button"


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- `NoteTooltip`에 `className` prop 추가, 기본값 `sm:hidden`으로 외부에서 반응형 분기점 제어 가능하도록 개선
- `MassageChairSection`, `SelfStudySection`의 `NoteTooltip`에 `className="lg:hidden"` 전달 — 태블릿(640px~1024px) 구간 안내 문구 누락 문제 해결
- `SelfStudySection` 라인 148 템플릿 리터럴 내 클래스명 공백 누락 버그 수정
- `NoteTooltip`에 스크롤·리사이즈 시 툴팁 자동 닫기 `useEffect` 추가
- `StudyFilterModal` 모달 배경색 `bg-white/30` → `bg-background/50` 으로 다크모드 대응

## 💬리뷰 요구사항

- PR #152 Gemini 코드 리뷰 반영 사항입니다.