### PR TITLE
fix: 긴 과목명 시간표 레이아웃 수정 및 조건부 fetch 정리

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -11,17 +11,17 @@ export default function MainPage() {
   return (
     <main className="flex-1 overflow-auto px-5 pb-25 sm:px-8 lg:px-10 2xl:px-18">
       <div className="mb-4 grid grid-cols-1 gap-4 lg:mb-5 lg:grid-cols-2 lg:gap-x-6 lg:gap-y-5 2xl:mb-6 2xl:grid-cols-[562fr_426fr_480fr]">
-        <div className="order-1 max-sm:hidden lg:col-span-2 2xl:col-span-1 2xl:col-start-3 2xl:row-start-1">
+        <div className="order-1 min-w-0 max-sm:hidden lg:col-span-2 2xl:col-span-1 2xl:col-start-3 2xl:row-start-1">
           <ProfileCard />
         </div>
-        <div className="order-2 lg:col-span-2 2xl:col-span-1 2xl:col-start-3 2xl:row-start-2">
+        <div className="order-2 min-w-0 lg:col-span-2 2xl:col-span-1 2xl:col-start-3 2xl:row-start-2">
           <TimeTableCardBoundary />
         </div>
-        <div className="order-3 flex flex-col gap-4 lg:gap-6 2xl:col-start-1 2xl:row-span-2 2xl:row-start-1">
+        <div className="order-3 flex min-w-0 flex-col gap-4 lg:gap-6 2xl:col-start-1 2xl:row-span-2 2xl:row-start-1">
           <StudyApplyCard />
           <MassageApplyCard />
         </div>
-        <div className="order-4 2xl:col-start-2 2xl:row-span-2 2xl:row-start-1">
+        <div className="order-4 min-w-0 2xl:col-start-2 2xl:row-span-2 2xl:row-start-1">
           <MealCardBoundary />
         </div>
       </div>

--- a/src/entities/neis/api/neisQueries.ts
+++ b/src/entities/neis/api/neisQueries.ts
@@ -6,7 +6,8 @@ export const neisQueries = {
   timetables: (params: TimetableParams) =>
     queryOptions({
       queryKey: ["neis", "timetables", params],
-      queryFn: () => getTimetables(params),
+      queryFn: async () =>
+        params.grade && params.classNumber ? getTimetables(params) : [],
     }),
 
   meals: (date: string) =>

--- a/src/entities/neis/api/neisQueries.ts
+++ b/src/entities/neis/api/neisQueries.ts
@@ -3,12 +3,15 @@ import { getTimetables, getMeals } from "@/entities/neis/api/getNeis";
 import type { TimetableParams } from "@/entities/neis/model/neis";
 
 export const neisQueries = {
-  timetables: (params: TimetableParams) =>
-    queryOptions({
-      queryKey: ["neis", "timetables", params],
-      queryFn: async () =>
-        params.grade && params.classNumber ? getTimetables(params) : [],
-    }),
+  timetables: (params: TimetableParams) => {
+    const hasClassInfo = !!(params.grade && params.classNumber);
+    return queryOptions({
+      queryKey: hasClassInfo
+        ? ["neis", "timetables", params]
+        : ["neis", "timetables", "empty"],
+      queryFn: async () => (hasClassInfo ? getTimetables(params) : []),
+    });
+  },
 
   meals: (date: string) =>
     queryOptions({

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -115,7 +115,7 @@ function TimeTableCardContent({
   }, [currentPeriod, timetables]);
 
   return (
-    <div className="flex h-[262px] flex-col gap-3 overflow-auto">
+    <div className="scrollbar-hide flex h-[262px] flex-col gap-3 overflow-auto">
       {!canFetchTimetable ? (
         <TimeTableCard.Empty />
       ) : timetables.length > 0 ? (
@@ -126,7 +126,7 @@ function TimeTableCardContent({
             <div
               key={it.period}
               ref={active ? activeRef : undefined}
-              className={`bg-sub-4 flex items-center gap-3 rounded-lg px-6 py-4 ${
+              className={`bg-sub-4 flex min-w-0 items-center gap-3 rounded-lg px-6 py-4 ${
                 active ? "border-p-1 border" : ""
               }`}
             >
@@ -181,7 +181,7 @@ const TimeTableCard = () => {
   };
 
   return (
-    <div className="bg-background-surface flex h-[354px] w-full flex-col rounded-2xl p-5 sm:p-6">
+    <div className="bg-background-surface flex h-[354px] w-full min-w-0 flex-col rounded-2xl p-5 sm:p-6">
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-1">
           <Calendar />

--- a/src/widgets/main/ui/TimeTableCard.tsx
+++ b/src/widgets/main/ui/TimeTableCard.tsx
@@ -4,7 +4,6 @@ import { Suspense, useEffect, useRef, useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import Back from "@/shared/asset/svg/Back";
 import Calendar from "@/shared/asset/svg/Calender";
-import { getTimetables } from "@/entities/neis/api/getNeis";
 import { neisQueries } from "@/entities/neis/api/neisQueries";
 import {
   NEIS_OFFICE_CODE,
@@ -82,7 +81,6 @@ function TimeTableContentLoading() {
 }
 
 interface TimeTableCardContentProps {
-  canFetchTimetable: boolean;
   timetableParams: {
     officeCode: string;
     schoolCode: string;
@@ -94,21 +92,14 @@ interface TimeTableCardContentProps {
 }
 
 function TimeTableCardContent({
-  canFetchTimetable,
   timetableParams,
   currentPeriod,
 }: TimeTableCardContentProps) {
   const activeRef = useRef<HTMLDivElement>(null);
 
-  const timetableQuery = neisQueries.timetables(timetableParams);
-  const { data: timetables } = useSuspenseQuery({
-    ...timetableQuery,
-    queryKey: canFetchTimetable
-      ? timetableQuery.queryKey
-      : ["neis", "timetables", "empty", timetableParams.date],
-    queryFn: () =>
-      canFetchTimetable ? getTimetables(timetableParams) : Promise.resolve([]),
-  });
+  const { data: timetables } = useSuspenseQuery(
+    neisQueries.timetables(timetableParams),
+  );
 
   useEffect(() => {
     activeRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
@@ -116,9 +107,7 @@ function TimeTableCardContent({
 
   return (
     <div className="scrollbar-hide flex h-[262px] flex-col gap-3 overflow-auto">
-      {!canFetchTimetable ? (
-        <TimeTableCard.Empty />
-      ) : timetables.length > 0 ? (
+      {timetables.length > 0 ? (
         timetables.map((it) => {
           const active = it.period === currentPeriod;
           const times = PERIOD_TIMES[it.period];
@@ -171,7 +160,6 @@ const TimeTableCard = () => {
   const currentPeriod = debouncedOffset === 0 ? getCurrentPeriod() : null;
 
   const { data: user } = useSuspenseQuery(userQueries.me());
-  const canFetchTimetable = !!user.grade && !!user.classNumber;
   const timetableParams = {
     officeCode: NEIS_OFFICE_CODE,
     schoolCode: NEIS_SCHOOL_CODE,
@@ -211,7 +199,6 @@ const TimeTableCard = () => {
 
       <Suspense fallback={<TimeTableContentLoading />}>
         <TimeTableCardContent
-          canFetchTimetable={canFetchTimetable}
           timetableParams={timetableParams}
           currentPeriod={currentPeriod}
         />


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 긴 과목명일 때 시간표 컨테이너 너비가 변동되던 문제 수정 (각 영역에 `min-w-0` 적용, 과목명 가로 스크롤 마스크 처리)
- 시간표 조건부 fetch 처리를 정리: `useSuspenseQuery` 호출부의 가짜 queryKey + `Promise.resolve([])` 우회 코드를 제거하고, 학년/반 유무 분기를 `neisQueries.timetables`의 `queryFn`으로 이동
- `canFetchTimetable` prop drilling 제거

https://github.com/user-attachments/assets/ffa7827e-7ad0-4934-a3a5-33b5cc8e6c9d


## 💬리뷰 요구사항

- 학년/반 정보가 없는 계정에서 시간표 API 요청이 발생하지 않고 "시간표 정보가 없습니다."가 노출되는지 확인