### PR TITLE
fix: 모바일 브라우저 Temporal polyfill 미적용 수정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,3 @@
-import "temporal-polyfill/global";
 import type { Metadata } from "next";
 import "@sun-typeface/suit/fonts/variable/woff2/SUIT-Variable.css";
 import "./globals.css";

--- a/src/entities/neis/lib/getCurrentMealType.ts
+++ b/src/entities/neis/lib/getCurrentMealType.ts
@@ -1,3 +1,4 @@
+import type { Temporal } from "temporal-polyfill";
 import {
   MEAL_TYPE_END_MINUTES,
   type MealType,

--- a/src/features/wake-up-music/lib/date.ts
+++ b/src/features/wake-up-music/lib/date.ts
@@ -1,3 +1,4 @@
+import type { Temporal } from "temporal-polyfill";
 import { todayKst } from "@/shared/lib/kst";
 
 export function getInitialMusicDate(): Temporal.PlainDate {

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -1,3 +1,4 @@
+import type { Temporal } from "temporal-polyfill";
 import { parseKstWallClock } from "@/shared/lib/kst";
 
 interface FormatDateParamOptions {

--- a/src/shared/lib/kst.ts
+++ b/src/shared/lib/kst.ts
@@ -1,3 +1,5 @@
+import { Temporal } from "temporal-polyfill";
+
 const KST_TIME_ZONE = "Asia/Seoul";
 
 /**

--- a/src/shared/lib/timeWindow.ts
+++ b/src/shared/lib/timeWindow.ts
@@ -1,3 +1,4 @@
+import type { Temporal } from "temporal-polyfill";
 import { minutesOfDay } from "@/shared/lib/kst";
 
 export interface TimeOfDay {

--- a/src/shared/lib/useCurrentTime.ts
+++ b/src/shared/lib/useCurrentTime.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { Temporal } from "temporal-polyfill";
 import { nowKst } from "@/shared/lib/kst";
 
 export function useCurrentTime(intervalMs = 5_000): Temporal.PlainDateTime {

--- a/src/shared/ui/Calendar.tsx
+++ b/src/shared/ui/Calendar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type { Temporal } from "temporal-polyfill";
 import Back from "@/shared/asset/svg/Back";
 import { todayKst } from "@/shared/lib/kst";
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#159

## 📝작업 내용

- `temporal-polyfill/global` 전역 import를 서버 컴포넌트(`app/layout.tsx`)에서 제거
- 서버 컴포넌트의 사이드이펙트 import는 클라이언트 번들에 포함되지 않아, 네이티브 Temporal 미지원 환경(iOS Safari·Samsung Browser)에서 `Temporal is not defined`로 로그인이 불가능했던 문제를 해결
- 직접 import하여 polyfill이 클라이언트 번들에 결정적으로 포함되도록 변경
- `import type { Temporal } from "temporal-polyfill"`로 전역 타입 의존 제거
- SSR/클라이언트가 동일한 polyfill 구현을 사용하도록 일원화

## 💬리뷰 요구사항

- [x] Samsung Browser에서 OAuth 로그인 및 시간 정상 렌더를 확인하였습니다.