### PR TITLE
change: 학생 검색 role 반영 및 권한 변경 UX 개선

### DIFF
--- a/src/entities/user/api/userHandlers.ts
+++ b/src/entities/user/api/userHandlers.ts
@@ -48,6 +48,7 @@ export const userHandlers = [
         classNumber,
         number,
         isBanned,
+        role,
       }) => ({
         id,
         name: sName,
@@ -57,6 +58,7 @@ export const userHandlers = [
         classNumber,
         number,
         isBanned,
+        role,
       }),
     );
 

--- a/src/entities/user/lib/userRole.ts
+++ b/src/entities/user/lib/userRole.ts
@@ -1,6 +1,7 @@
 import type { User, UserRole } from "@/entities/user/model/user";
 
-const roleLabels: Partial<Record<UserRole, string>> = {
+const roleLabels: Record<UserRole, string> = {
+  GENERAL_STUDENT: "일반 학생",
   ADMIN: "관리자",
   DORMITORY_MANAGER: "기자위",
   STUDENT_COUNCIL: "학생회",
@@ -11,7 +12,7 @@ export function getRoleLabel(role?: UserRole): string | null {
     return null;
   }
 
-  return roleLabels[role] ?? null;
+  return roleLabels[role];
 }
 
 const DORMITORY_TEACHER_NAME = "사감선생님";

--- a/src/entities/user/model/user.ts
+++ b/src/entities/user/model/user.ts
@@ -33,7 +33,7 @@ export interface SearchUser {
   classNumber: number;
   number: number;
   isBanned: boolean;
-  role?: UserRole;
+  role: UserRole;
 }
 
 export interface SearchUsersPage {

--- a/src/features/self-study/ui/ManagedStudentCard.tsx
+++ b/src/features/self-study/ui/ManagedStudentCard.tsx
@@ -66,9 +66,7 @@ export function ManagedStudentCard({
         <span className="text-caption-1 text-sub-1">
           {student.studentNumber}
         </span>
-        {roleLabel && (
-          <span className="text-caption-3 text-p-1">{roleLabel}</span>
-        )}
+        <span className="text-caption-3 text-p-1">{roleLabel}</span>
       </div>
     </button>
   );

--- a/src/features/self-study/ui/StudentManagementSection.tsx
+++ b/src/features/self-study/ui/StudentManagementSection.tsx
@@ -150,7 +150,9 @@ const StudentManagementSection = () => {
     if (isDeselect) {
       setSelectedRole("");
     } else {
-      const targetStudent = students.find((student) => student.id === studentId);
+      const targetStudent = students.find(
+        (student) => student.id === studentId,
+      );
       setSelectedRole(targetStudent?.role ?? "");
     }
   };

--- a/src/features/self-study/ui/StudentManagementSection.tsx
+++ b/src/features/self-study/ui/StudentManagementSection.tsx
@@ -91,6 +91,10 @@ const StudentManagementSection = () => {
   );
   const [selectedRole, setSelectedRole] = useState<UserRole | "">("");
   const students = studentPage?.content ?? [];
+  const selectedStudent = students.find(
+    (student) => student.id === selectedStudentId,
+  );
+  const isSelectedStudentAdmin = selectedStudent?.role === "ADMIN";
 
   const filteredStudents = filterManagedStudents({
     students,
@@ -141,8 +145,10 @@ const StudentManagementSection = () => {
   };
 
   const handleToggleStudentSelect = (studentId: number) => {
-    setSelectedStudentId((prev) => (prev === studentId ? null : studentId));
-    setSelectedRole("");
+    const isDeselect = selectedStudentId === studentId;
+    setSelectedStudentId(isDeselect ? null : studentId);
+    const nextRole = students.find((student) => student.id === studentId)?.role;
+    setSelectedRole(isDeselect || !nextRole ? "" : nextRole);
   };
 
   const handleBanStudent = () => {
@@ -227,13 +233,15 @@ const StudentManagementSection = () => {
             onUnbanStudent={handleUnbanStudent}
           />
 
-          <StudentRoleActionPanel
-            hasSelectedStudent={selectedStudentId !== null}
-            selectedRole={selectedRole}
-            isPending={patchUserRoleMutation.isPending}
-            onSelectRole={setSelectedRole}
-            onChangeRole={handleChangeRole}
-          />
+          {!isSelectedStudentAdmin && (
+            <StudentRoleActionPanel
+              hasSelectedStudent={selectedStudentId !== null}
+              selectedRole={selectedRole}
+              isPending={patchUserRoleMutation.isPending}
+              onSelectRole={setSelectedRole}
+              onChangeRole={handleChangeRole}
+            />
+          )}
         </aside>
       </div>
     </section>

--- a/src/features/self-study/ui/StudentManagementSection.tsx
+++ b/src/features/self-study/ui/StudentManagementSection.tsx
@@ -147,8 +147,12 @@ const StudentManagementSection = () => {
   const handleToggleStudentSelect = (studentId: number) => {
     const isDeselect = selectedStudentId === studentId;
     setSelectedStudentId(isDeselect ? null : studentId);
-    const nextRole = students.find((student) => student.id === studentId)?.role;
-    setSelectedRole(isDeselect || !nextRole ? "" : nextRole);
+    if (isDeselect) {
+      setSelectedRole("");
+    } else {
+      const targetStudent = students.find((student) => student.id === studentId);
+      setSelectedRole(targetStudent?.role ?? "");
+    }
   };
 
   const handleBanStudent = () => {


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 학생 검색 API 응답에 `role`이 추가됨에 따라 `SearchUser.role`을 필수 필드로 변경
- 검색 mock 핸들러가 응답에 `role`을 포함하도록 수정
- 학생 선택 시 권한 변경 드롭다운에 해당 학생의 현재 권한을 프리필
- 선택한 학생이 어드민(`ADMIN`)이면 권한 변경 패널을 숨김 처리

<img width="2160" height="1550" alt="image" src="https://github.com/user-attachments/assets/ff437205-8f64-4846-9841-81006fd3f864" />


## 💬리뷰 요구사항

- 어드민이 아닌 `ASSIGNABLE_ROLES`에 없는 역할이 들어올 경우의 드롭다운 표기가 의도대로인지 확인 부탁드립니다.
