### PR TITLE
fix: 프로필 카드 역할 색상 적용 및 기상음악 스크롤 개선

### DIFF
--- a/src/entities/dormitory/api/dormitoryHandlers.ts
+++ b/src/entities/dormitory/api/dormitoryHandlers.ts
@@ -16,7 +16,7 @@ export const dormitoryHandlers = [
     const songs = [...MOCK_SONGS].sort((a, b) =>
       sort === "LIKE"
         ? b.likeCount - a.likeCount
-        : new Date(b.appliedAt).getTime() - new Date(a.appliedAt).getTime(),
+        : b.appliedAt.localeCompare(a.appliedAt),
     );
 
     return HttpResponse.json({

--- a/src/widgets/main/ui/MyProfileCard.tsx
+++ b/src/widgets/main/ui/MyProfileCard.tsx
@@ -28,7 +28,7 @@ export default function MyProfileCard() {
           </span>
           {roleLabel && (
             <span
-              className={`text-text-3 ${user?.role == "GENERAL_STUDENT" ? "text-sub-1" : "text-negative"} font-medium`}
+              className={`text-text-3 ${user?.role === "GENERAL_STUDENT" ? "text-sub-1" : "text-negative"} font-medium`}
             >
               {roleLabel}
             </span>

--- a/src/widgets/sidebar/ui/sidebarDrawer.tsx
+++ b/src/widgets/sidebar/ui/sidebarDrawer.tsx
@@ -62,7 +62,7 @@ export function SidebarDrawer({ isOpen, onClose }: SidebarDrawerProps) {
                   </span>
                   {roleLabel && (
                     <span
-                      className={`text-text-3 ${user?.role == "GENERAL_STUDENT" ? "text-sub-1" : "text-negative"} font-medium`}
+                      className={`text-text-3 ${user?.role === "GENERAL_STUDENT" ? "text-sub-1" : "text-negative"} font-medium`}
                     >
                       {roleLabel}
                     </span>


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 머지 후 리버트된 작업을 재적용하기 위해 PR을 다시 생성했습니다.
- 프로필 카드(MyProfileCard, sidebarDrawer)에서 역할별 라벨 색상을 분기 적용했습니다.
- 기존 ProfileCard를 MyProfileCard / StudentProfileCard로 분리해 구조를 명확히 했습니다.
- 기상음악 섹션 레이아웃에 스크롤 스타일을 보완했습니다.
- 스크롤 검증용 기상음악 목 데이터 및 모킹 핸들러를 추가했습니다.
- 리뷰 피드백을 반영해 목 핸들러 정렬에 `localeCompare`를 사용하고, 역할 비교를 엄격한 비교(`===`)로 변경했습니다.

## 💬리뷰 요구사항

- 리버트로 인한 재생성 PR이므로, develop에 이전 작업이 누락 없이 반영되는지 확인 부탁드립니다.