### PR TITLE
fix: 모바일 기상음악 목록 스크롤 동작 수정

### DIFF
--- a/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
+++ b/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
@@ -90,8 +90,8 @@ export function WakeUpMusicSection({
       </div>
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col-reverse gap-6 overflow-hidden lg:flex-row">
-        <div className="relative max-h-[360px] min-h-0 min-w-0 flex-1 lg:max-h-none">
-          <div className="h-full overflow-x-hidden overflow-y-auto lg:absolute lg:inset-0 lg:pr-2">
+        <div className="relative min-h-0 min-w-0 flex-1">
+          <div className="max-h-[360px] overflow-x-hidden overflow-y-auto lg:absolute lg:inset-0 lg:max-h-none lg:pr-2">
             <div className="flex min-w-0 flex-col">
               {songs.map((music) => (
                 <MusicListItem


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 모바일 레이아웃에서 기상음악 신청 목록이 스크롤되지 않던 문제를 수정했습니다.
- 스크롤 컨테이너가 `max-height`만 가진 부모에 `h-full`로 의존해 모바일에서 높이가 resolve되지 않아 overflow가 발생하지 않던 것이 원인입니다.
- 스크롤 영역에 `max-h`와 `overflow`를 직접 부여하고, 데스크톱(lg)에서는 기존 `absolute inset-0` 방식을 유지하도록 변경했습니다.

## 💬리뷰 요구사항

- 모바일/데스크톱 양쪽에서 기상음악 목록 스크롤이 정상 동작하는지 확인 부탁드립니다.
- `compact` 모드(기숙사 페이지)에서도 동일 섹션을 사용하니 함께 확인 부탁드립니다.