### PR TITLE
fix: 토큰 재발급·SSE 인증 흐름 개편으로 세션 복구 안정화

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import axios, { HttpStatusCode } from "axios";
 import { NextRequest, NextResponse } from "next/server";
 import { LONG_API_TIMEOUT_MS, serverInstance } from "@/shared/api/instance";
+import { COOKIE_CONFIG } from "@/shared/config/cookie";
 
 export async function POST(request: NextRequest) {
   const { code } = await request.json();
@@ -21,13 +22,11 @@ export async function POST(request: NextRequest) {
     const res = NextResponse.json(response.data, { status: response.status });
 
     if (refreshToken) {
-      res.cookies.set("refresh_token", refreshToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 14,
-      });
+      res.cookies.set(
+        COOKIE_CONFIG.refreshToken.name,
+        refreshToken,
+        COOKIE_CONFIG.refreshToken.options,
+      );
     }
 
     return res;
@@ -38,15 +37,11 @@ export async function POST(request: NextRequest) {
       const { data, status } = error.response;
       const body = data ?? fallbackBody;
 
-      if (status === HttpStatusCode.BadRequest) {
-        return NextResponse.json(body, { status });
-      }
-
-      if (status === HttpStatusCode.Unauthorized) {
-        return NextResponse.json(body, { status });
-      }
-
-      if (status === HttpStatusCode.InternalServerError) {
+      if (
+        status === HttpStatusCode.BadRequest ||
+        status === HttpStatusCode.Unauthorized ||
+        status === HttpStatusCode.InternalServerError
+      ) {
         return NextResponse.json(body, { status });
       }
     }

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,9 +1,12 @@
 import axios, { HttpStatusCode } from "axios";
 import { NextRequest, NextResponse } from "next/server";
 import { serverInstance } from "@/shared/api/instance";
+import { COOKIE_CONFIG } from "@/shared/config/cookie";
 
 export async function POST(request: NextRequest) {
-  const refreshToken = request.cookies.get("refresh_token")?.value;
+  const refreshToken = request.cookies.get(
+    COOKIE_CONFIG.refreshToken.name,
+  )?.value;
 
   if (!refreshToken) {
     return NextResponse.json(
@@ -23,13 +26,11 @@ export async function POST(request: NextRequest) {
     const res = NextResponse.json(response.data, { status: response.status });
 
     if (newRefreshToken) {
-      res.cookies.set("refresh_token", newRefreshToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 14,
-      });
+      res.cookies.set(
+        COOKIE_CONFIG.refreshToken.name,
+        newRefreshToken,
+        COOKIE_CONFIG.refreshToken.options,
+      );
     }
 
     return res;
@@ -45,11 +46,8 @@ export async function POST(request: NextRequest) {
         status === HttpStatusCode.Unauthorized
       ) {
         const res = NextResponse.json(body, { status });
-        res.cookies.set("refresh_token", "", {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === "production",
-          sameSite: "lax",
-          path: "/",
+        res.cookies.set(COOKIE_CONFIG.refreshToken.name, "", {
+          ...COOKIE_CONFIG.refreshToken.options,
           maxAge: 0,
         });
         return res;

--- a/app/api/auth/signout/route.ts
+++ b/app/api/auth/signout/route.ts
@@ -1,12 +1,10 @@
 import { NextResponse } from "next/server";
+import { COOKIE_CONFIG } from "@/shared/config/cookie";
 
 export async function POST() {
   const response = NextResponse.json({ success: true });
-  response.cookies.set("refresh_token", "", {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
-    path: "/",
+  response.cookies.set(COOKIE_CONFIG.refreshToken.name, "", {
+    ...COOKIE_CONFIG.refreshToken.options,
     maxAge: 0,
   });
   return response;

--- a/app/callback/page.tsx
+++ b/app/callback/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useRef, useState } from "react";
 import { instance, LONG_ROUTE_TIMEOUT_MS } from "@/shared/api/instance";
+import { AUTH_ROUTES } from "@/shared/config/routes";
 import { TextButton } from "@/shared/ui/Button/TextButton";
 
 type CallbackStatus = "loading" | "error";
@@ -29,7 +30,7 @@ function CallbackInner() {
     (async () => {
       try {
         const { data } = await instance.post(
-          "/api/auth/callback",
+          AUTH_ROUTES.callback,
           {
             code,
           },

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,9 +6,26 @@ import { OAuthProvider } from "@themoment-team/datagsm-oauth-react";
 import * as Sentry from "@sentry/nextjs";
 import { Toaster } from "sonner";
 import { queryClient } from "@/shared/api/queryClient";
+import { refreshAccessToken } from "@/shared/api/instance";
 import { userQueries } from "@/entities/user/api/userQueries";
 import type { User } from "@/entities/user/model/user";
 import { MSWProvider } from "./msw-provider";
+
+/**
+ * 앱 진입 시 access_token이 없으면(탭 종료/새로고침 등으로 sessionStorage 소멸)
+ * refresh_token 쿠키로 선제 복구한다. 렌더링은 막지 않으며, 인터셉터와 동일한
+ * refresh 프로미스를 공유하므로 중복 호출이 발생하지 않는다.
+ */
+function SessionRestorer() {
+  useEffect(() => {
+    if (sessionStorage.getItem("access_token")) return;
+    refreshAccessToken().catch(() => {
+      // refresh_token 없음/만료 → 인터셉터가 401 시 /signin 처리
+    });
+  }, []);
+
+  return null;
+}
 
 function SentryUserBridge() {
   useEffect(() => {
@@ -48,6 +65,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     <MSWProvider>
       <QueryClientProvider client={queryClient}>
         <SentryUserBridge />
+        <SessionRestorer />
         <OAuthProvider
           clientId={process.env.NEXT_PUBLIC_DG_CLIENT_ID!}
           redirectUri={process.env.NEXT_PUBLIC_DG_REDIRECT_URL!}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,26 +6,9 @@ import { OAuthProvider } from "@themoment-team/datagsm-oauth-react";
 import * as Sentry from "@sentry/nextjs";
 import { Toaster } from "sonner";
 import { queryClient } from "@/shared/api/queryClient";
-import { refreshAccessToken } from "@/shared/api/instance";
 import { userQueries } from "@/entities/user/api/userQueries";
 import type { User } from "@/entities/user/model/user";
 import { MSWProvider } from "./msw-provider";
-
-/**
- * 앱 진입 시 access_token이 없으면(탭 종료/새로고침 등으로 sessionStorage 소멸)
- * refresh_token 쿠키로 선제 복구한다. 렌더링은 막지 않으며, 인터셉터와 동일한
- * refresh 프로미스를 공유하므로 중복 호출이 발생하지 않는다.
- */
-function SessionRestorer() {
-  useEffect(() => {
-    if (sessionStorage.getItem("access_token")) return;
-    refreshAccessToken().catch(() => {
-      // refresh_token 없음/만료 → 인터셉터가 401 시 /signin 처리
-    });
-  }, []);
-
-  return null;
-}
 
 function SentryUserBridge() {
   useEffect(() => {
@@ -65,7 +48,6 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     <MSWProvider>
       <QueryClientProvider client={queryClient}>
         <SentryUserBridge />
-        <SessionRestorer />
         <OAuthProvider
           clientId={process.env.NEXT_PUBLIC_DG_CLIENT_ID!}
           redirectUri={process.env.NEXT_PUBLIC_DG_REDIRECT_URL!}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-query-devtools": "^5.91.3",
         "@themoment-team/datagsm-oauth-react": "^1.1.1",
         "axios": "^1.13.4",
+        "eventsource": "^4.1.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -5307,6 +5308,27 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
+      "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/exsolve": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-query-devtools": "^5.91.3",
     "@themoment-team/datagsm-oauth-react": "^1.1.1",
     "axios": "^1.13.4",
+    "eventsource": "^4.1.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-
-const publicPages = ["/signin", "/callback"];
+import { COOKIE_CONFIG } from "@/shared/config/cookie";
+import { PUBLIC_ROUTES } from "@/shared/config/routes";
 
 export const config = {
   matcher: [
@@ -14,7 +14,9 @@ function isSafeRedirectPath(path: string): boolean {
 
 export function proxy(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl;
-  const refreshToken = request.cookies.get("refresh_token")?.value;
+  const refreshToken = request.cookies.get(
+    COOKIE_CONFIG.refreshToken.name,
+  )?.value;
 
   if (pathname === "/signin" && refreshToken) {
     const redirectTo = searchParams.get("redirectTo");
@@ -26,7 +28,7 @@ export function proxy(request: NextRequest) {
     return NextResponse.redirect(new URL("/", request.url));
   }
 
-  if (!publicPages.includes(pathname) && !refreshToken) {
+  if (!PUBLIC_ROUTES.some((page) => page === pathname) && !refreshToken) {
     const signinUrl = new URL("/signin", request.url);
     const intendedPath = request.nextUrl.pathname + request.nextUrl.search;
 

--- a/src/features/self-study/model/useStudyAttendanceSubscription.ts
+++ b/src/features/self-study/model/useStudyAttendanceSubscription.ts
@@ -10,6 +10,7 @@ import type { UserRole } from "@/entities/user/model/user";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { toast } from "sonner";
+import { openAuthorizedSse } from "@/shared/api/authorizedSse";
 
 export function useStudyAttendanceSubscription(role?: UserRole) {
   const queryClient = useQueryClient();
@@ -17,10 +18,6 @@ export function useStudyAttendanceSubscription(role?: UserRole) {
   useEffect(() => {
     const studyPermission = createStudyPermission({ role });
     if (!studyPermission.canCheckAttendance) return;
-
-    const accessToken = sessionStorage.getItem("access_token");
-    const searchParams = new URLSearchParams();
-    if (accessToken) searchParams.set("accessToken", accessToken);
 
     const streamKey = dormitoryQueries.studyAttendanceStream().queryKey;
 
@@ -87,34 +84,17 @@ export function useStudyAttendanceSubscription(role?: UserRole) {
       }));
     };
 
-    const handleOpen = () => setStreamStatus("open");
-    const handleError = () => setStreamStatus("error");
-
     setStreamStatus("connecting");
 
-    const eventSource = new EventSource(
-      `/api/dormitory/studies/attendance?${searchParams.toString()}`,
-    );
-
-    eventSource.addEventListener("open", handleOpen);
-    eventSource.addEventListener("error", handleError);
-    eventSource.addEventListener("init", handleInitEvent);
-    eventSource.addEventListener("attendance", handleAttendanceEvent);
-    eventSource.addEventListener(
-      "cancel-attendance",
-      handleCancelAttendanceEvent,
-    );
-
-    return () => {
-      eventSource.removeEventListener("open", handleOpen);
-      eventSource.removeEventListener("error", handleError);
-      eventSource.removeEventListener("init", handleInitEvent);
-      eventSource.removeEventListener("attendance", handleAttendanceEvent);
-      eventSource.removeEventListener(
-        "cancel-attendance",
-        handleCancelAttendanceEvent,
-      );
-      eventSource.close();
-    };
+    return openAuthorizedSse({
+      path: "/api/dormitory/studies/attendance",
+      listeners: {
+        init: handleInitEvent,
+        attendance: handleAttendanceEvent,
+        "cancel-attendance": handleCancelAttendanceEvent,
+      },
+      onOpen: () => setStreamStatus("open"),
+      onError: () => setStreamStatus("error"),
+    });
   }, [queryClient, role]);
 }

--- a/src/features/sign-out/lib/useSignOut.ts
+++ b/src/features/sign-out/lib/useSignOut.ts
@@ -1,10 +1,11 @@
 import { useRouter } from "next/navigation";
+import { AUTH_ROUTES } from "@/shared/config/routes";
 
 export const useSignOut = () => {
   const router = useRouter();
 
   const handleSignout = async () => {
-    await fetch("/api/auth/signout", { method: "POST" });
+    await fetch(AUTH_ROUTES.signout, { method: "POST" });
     sessionStorage.removeItem("access_token");
     router.push("/signin");
   };

--- a/src/features/sign-out/lib/useSignOut.ts
+++ b/src/features/sign-out/lib/useSignOut.ts
@@ -6,7 +6,6 @@ export const useSignOut = () => {
   const handleSignout = async () => {
     await fetch("/api/auth/signout", { method: "POST" });
     sessionStorage.removeItem("access_token");
-    sessionStorage.removeItem("user");
     router.push("/signin");
   };
 

--- a/src/features/wake-up-music/model/useWakeUpMusicSubscription.ts
+++ b/src/features/wake-up-music/model/useWakeUpMusicSubscription.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { openAuthorizedSse } from "@/shared/api/authorizedSse";
 import { formatDateParam } from "@/shared/lib/date";
 import { todayKst } from "@/shared/lib/kst";
 
@@ -12,10 +13,6 @@ export function useWakeUpMusicSubscription() {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    const accessToken = sessionStorage.getItem("access_token");
-    const searchParams = new URLSearchParams();
-    if (accessToken) searchParams.set("accessToken", accessToken);
-
     const invalidateToday = () => {
       // 자정 롤오버에 대응하기 위해 이벤트 수신 시점에 오늘 날짜를 계산한다.
       const today = formatDateParam(todayKst());
@@ -24,20 +21,14 @@ export function useWakeUpMusicSubscription() {
       });
     };
 
-    const eventSource = new EventSource(
-      `/api/dormitory/music/subscribe?${searchParams.toString()}`,
-    );
-
-    eventSource.addEventListener("init", invalidateToday);
-    eventSource.addEventListener("music-applied", invalidateToday);
-    eventSource.addEventListener("music-cancelled", invalidateToday);
-    eventSource.addEventListener("music-like-updated", invalidateToday);
-
-    return () => {
-      eventSource.removeEventListener("init", invalidateToday);
-      eventSource.removeEventListener("music-applied", invalidateToday);
-      eventSource.removeEventListener("music-cancelled", invalidateToday);
-      eventSource.close();
-    };
+    return openAuthorizedSse({
+      path: "/api/dormitory/music/subscribe",
+      listeners: {
+        init: invalidateToday,
+        "music-applied": invalidateToday,
+        "music-cancelled": invalidateToday,
+        "music-like-updated": invalidateToday,
+      },
+    });
   }, [queryClient]);
 }

--- a/src/shared/api/authorizedSse.ts
+++ b/src/shared/api/authorizedSse.ts
@@ -1,27 +1,25 @@
+import { HttpStatusCode } from "axios";
+import { EventSource, type FetchLike } from "eventsource";
 import { refreshAccessToken } from "@/shared/api/instance";
 
 interface AuthorizedSseConfig {
-  /** NEXT_PUBLIC 기준 SSE 라우트 경로 (예: "/api/dormitory/music/subscribe") */
   path: string;
-  /** 이벤트 타입 → 핸들러. open/error는 onOpen/onError로 전달한다. */
   listeners: Record<string, (event: MessageEvent<string>) => void>;
   onOpen?: () => void;
   onError?: () => void;
 }
 
-const INITIAL_RECONNECT_DELAY_MS = 1000;
-const MAX_RECONNECT_DELAY_MS = 30000;
-
 /**
- * access_token을 쿼리 파라미터로 실어 인증된 SSE에 연결한다.
+ * 인증된 SSE에 연결한다.
  *
- * EventSource는 Authorization 헤더를 보낼 수 없어 토큰을 쿼리로 전달하며,
- * 토큰 재발급은 전적으로 공유 refreshAccessToken()(/api/auth/refresh)에 위임한다.
- * 프록시는 더 이상 독립적으로 reissue하지 않으므로 refresh token 회전 경쟁이 없다.
+ * 표준 EventSource는 Authorization 헤더를 보낼 수 없어 토큰을 URL 쿼리로 싣고
+ * 재연결마다 만료된 토큰을 그대로 재사용하는 한계가 있다. 여기서는 fetch 주입을
+ * 지원하는 eventsource 라이브러리를 사용해, 재연결마다 호출되는 fetch가
+ * sessionStorage의 최신 access_token을 Authorization 헤더로 싣는다.
  *
- * 재연결 정책:
- * - 연결이 한 번도 open되지 않고 끊기면(=인증 실패 가능성) 토큰을 새로 받아 재연결한다.
- * - open된 뒤 끊기면(=스트림 드롭/백엔드 init 종료) 토큰 회전 없이 재연결해 회전 폭주를 막는다.
+ * - 401이면 공유 refreshAccessToken()으로 갱신해 1회 재시도한다.
+ * - 갱신까지 실패하면 401을 그대로 반환해 라이브러리가 재연결을 멈춘다(무한 루프 방지).
+ * - 단순 네트워크 드롭의 재연결·Last-Event-ID는 라이브러리에 위임한다.
  *
  * @returns 정리(cleanup) 함수
  */
@@ -31,56 +29,29 @@ export function openAuthorizedSse({
   onOpen,
   onError,
 }: AuthorizedSseConfig): () => void {
-  let eventSource: EventSource | null = null;
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  let reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
-  let closed = false;
+  const fetchWithAuth: FetchLike = async (url, init) => {
+    const request = (accessToken: string | null) =>
+      fetch(url, {
+        ...init,
+        headers: accessToken
+          ? { ...init.headers, Authorization: `Bearer ${accessToken}` }
+          : init.headers,
+      });
 
-  const scheduleReconnect = (forceRefresh: boolean) => {
-    if (closed || reconnectTimer) return;
-    reconnectTimer = setTimeout(() => {
-      reconnectTimer = null;
-      void connect(forceRefresh);
-    }, reconnectDelay);
-    reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY_MS);
+    const response = await request(sessionStorage.getItem("access_token"));
+    if (response.status !== HttpStatusCode.Unauthorized) return response;
+
+    const refreshed = await refreshAccessToken().catch(() => null);
+    return refreshed ? request(refreshed) : response;
   };
 
-  const connect = async (forceRefresh: boolean) => {
-    let token = sessionStorage.getItem("access_token");
-    if (!token || forceRefresh) {
-      token = await refreshAccessToken().catch(() => null);
-    }
-    if (closed || !token) return;
+  const eventSource = new EventSource(path, { fetch: fetchWithAuth });
 
-    const params = new URLSearchParams({ accessToken: token });
-    const source = new EventSource(`${path}?${params.toString()}`);
-    eventSource = source;
+  eventSource.addEventListener("open", () => onOpen?.());
+  eventSource.addEventListener("error", () => onError?.());
+  for (const [type, handler] of Object.entries(listeners)) {
+    eventSource.addEventListener(type, handler);
+  }
 
-    let opened = false;
-
-    source.addEventListener("open", () => {
-      opened = true;
-      reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
-      onOpen?.();
-    });
-
-    for (const [type, handler] of Object.entries(listeners)) {
-      source.addEventListener(type, handler as EventListener);
-    }
-
-    source.addEventListener("error", () => {
-      onError?.();
-      source.close();
-      // open조차 못 했으면 토큰 만료/인증 실패 가능성 → 새 토큰으로 재연결
-      scheduleReconnect(!opened);
-    });
-  };
-
-  void connect(false);
-
-  return () => {
-    closed = true;
-    if (reconnectTimer) clearTimeout(reconnectTimer);
-    eventSource?.close();
-  };
+  return () => eventSource.close();
 }

--- a/src/shared/api/authorizedSse.ts
+++ b/src/shared/api/authorizedSse.ts
@@ -1,0 +1,86 @@
+import { refreshAccessToken } from "@/shared/api/instance";
+
+interface AuthorizedSseConfig {
+  /** NEXT_PUBLIC 기준 SSE 라우트 경로 (예: "/api/dormitory/music/subscribe") */
+  path: string;
+  /** 이벤트 타입 → 핸들러. open/error는 onOpen/onError로 전달한다. */
+  listeners: Record<string, (event: MessageEvent<string>) => void>;
+  onOpen?: () => void;
+  onError?: () => void;
+}
+
+const INITIAL_RECONNECT_DELAY_MS = 1000;
+const MAX_RECONNECT_DELAY_MS = 30000;
+
+/**
+ * access_token을 쿼리 파라미터로 실어 인증된 SSE에 연결한다.
+ *
+ * EventSource는 Authorization 헤더를 보낼 수 없어 토큰을 쿼리로 전달하며,
+ * 토큰 재발급은 전적으로 공유 refreshAccessToken()(/api/auth/refresh)에 위임한다.
+ * 프록시는 더 이상 독립적으로 reissue하지 않으므로 refresh token 회전 경쟁이 없다.
+ *
+ * 재연결 정책:
+ * - 연결이 한 번도 open되지 않고 끊기면(=인증 실패 가능성) 토큰을 새로 받아 재연결한다.
+ * - open된 뒤 끊기면(=스트림 드롭/백엔드 init 종료) 토큰 회전 없이 재연결해 회전 폭주를 막는다.
+ *
+ * @returns 정리(cleanup) 함수
+ */
+export function openAuthorizedSse({
+  path,
+  listeners,
+  onOpen,
+  onError,
+}: AuthorizedSseConfig): () => void {
+  let eventSource: EventSource | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+  let closed = false;
+
+  const scheduleReconnect = (forceRefresh: boolean) => {
+    if (closed || reconnectTimer) return;
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      void connect(forceRefresh);
+    }, reconnectDelay);
+    reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY_MS);
+  };
+
+  const connect = async (forceRefresh: boolean) => {
+    let token = sessionStorage.getItem("access_token");
+    if (!token || forceRefresh) {
+      token = await refreshAccessToken().catch(() => null);
+    }
+    if (closed || !token) return;
+
+    const params = new URLSearchParams({ accessToken: token });
+    const source = new EventSource(`${path}?${params.toString()}`);
+    eventSource = source;
+
+    let opened = false;
+
+    source.addEventListener("open", () => {
+      opened = true;
+      reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+      onOpen?.();
+    });
+
+    for (const [type, handler] of Object.entries(listeners)) {
+      source.addEventListener(type, handler as EventListener);
+    }
+
+    source.addEventListener("error", () => {
+      onError?.();
+      source.close();
+      // open조차 못 했으면 토큰 만료/인증 실패 가능성 → 새 토큰으로 재연결
+      scheduleReconnect(!opened);
+    });
+  };
+
+  void connect(false);
+
+  return () => {
+    closed = true;
+    if (reconnectTimer) clearTimeout(reconnectTimer);
+    eventSource?.close();
+  };
+}

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -1,5 +1,9 @@
 import axios, { HttpStatusCode } from "axios";
 import { captureFeatureError } from "@/shared/lib/sentry";
+import { AUTH_ROUTES, PUBLIC_ROUTES } from "@/shared/config/routes";
+
+/** access_token 자동 재발급 인터셉터에서 제외할 인증 경로 */
+const authRoutesWithoutRefresh = Object.values(AUTH_ROUTES);
 
 export const DEFAULT_API_TIMEOUT_MS = 10 * 1000;
 export const LONG_API_TIMEOUT_MS = 30 * 1000;
@@ -17,18 +21,16 @@ export const serverInstance = axios.create({
   timeout: DEFAULT_API_TIMEOUT_MS,
 });
 
-const authPathsWithoutRefresh = [
-  "/api/auth/callback",
-  "/api/auth/refresh",
-  "/api/auth/signout",
-];
+export const sseInstance = axios.create({
+  headers: { Accept: "text/event-stream" },
+  responseType: "stream",
+  timeout: 0,
+});
 
 let refreshPromise: Promise<string> | null = null;
 
 function redirectToSignin() {
-  const authPages = ["/signin", "/callback"];
-
-  if (!authPages.includes(window.location.pathname)) {
+  if (!PUBLIC_ROUTES.some((page) => page === window.location.pathname)) {
     window.location.replace("/signin");
   }
 }
@@ -36,12 +38,13 @@ function redirectToSignin() {
 /**
  * refresh_token 쿠키로 access_token을 재발급한다.
  * 동시 호출은 하나의 요청으로 합쳐, rotating refresh token이 중복 호출로
- * 무효화되는 것을 방지한다. (인터셉터와 선제 복구가 함께 사용)
+ * 무효화되는 것을 방지한다. (요청 인터셉터의 선제 재발급, 응답 인터셉터의 401 복구,
+ * SSE 연결이 모두 이 프로미스를 공유한다.)
  */
 export function refreshAccessToken(): Promise<string> {
   if (!refreshPromise) {
     refreshPromise = axios
-      .post("/api/auth/refresh", undefined, {
+      .post(AUTH_ROUTES.refresh, undefined, {
         timeout: DEFAULT_ROUTE_TIMEOUT_MS,
       })
       .then(({ data }) => {
@@ -59,20 +62,37 @@ export function refreshAccessToken(): Promise<string> {
   return refreshPromise;
 }
 
-instance.interceptors.request.use((config) => {
+/**
+ * 요청 인터셉터: access_token이 없으면 공유 refreshAccessToken()에 합류해
+ * 토큰이 준비된 뒤 요청을 보낸다(요청 레벨 대기). 진입 시 401 폭포를 방지하며
+ * 화면 렌더링에는 관여하지 않는다.
+ */
+instance.interceptors.request.use(async (config) => {
   if (config.url?.startsWith("/api/")) {
     config.baseURL = undefined;
   }
 
-  if (typeof window !== "undefined") {
-    const token = sessionStorage.getItem("access_token");
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
+  if (typeof window === "undefined") return config;
+
+  const skipAuth = authRoutesWithoutRefresh.some((path) =>
+    config.url?.includes(path),
+  );
+
+  let token = sessionStorage.getItem("access_token");
+  if (!token && !skipAuth) {
+    token = await refreshAccessToken().catch(() => null);
+  }
+
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });
 
+/**
+ * 응답 인터셉터: 사용 중 access_token이 만료돼 401이 나면 1회 재발급·재시도한다.
+ * 재발급도 실패하면 세션을 정리하고 /signin으로 보낸다.
+ */
 instance.interceptors.response.use(
   (response) => response,
   async (error) => {
@@ -83,7 +103,7 @@ instance.interceptors.response.use(
     if (
       error.response?.status === HttpStatusCode.Unauthorized &&
       !config.headers["x-retried"] &&
-      !authPathsWithoutRefresh.some((path) => config.url?.includes(path))
+      !authRoutesWithoutRefresh.some((path) => config.url?.includes(path))
     ) {
       config.headers["x-retried"] = "true";
 

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -33,6 +33,32 @@ function redirectToSignin() {
   }
 }
 
+/**
+ * refresh_token 쿠키로 access_token을 재발급한다.
+ * 동시 호출은 하나의 요청으로 합쳐, rotating refresh token이 중복 호출로
+ * 무효화되는 것을 방지한다. (인터셉터와 선제 복구가 함께 사용)
+ */
+export function refreshAccessToken(): Promise<string> {
+  if (!refreshPromise) {
+    refreshPromise = axios
+      .post("/api/auth/refresh", undefined, {
+        timeout: DEFAULT_ROUTE_TIMEOUT_MS,
+      })
+      .then(({ data }) => {
+        const token = data.data?.accessToken;
+        if (!token) {
+          throw new Error("Access token is missing");
+        }
+        sessionStorage.setItem("access_token", token);
+        return token as string;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+  return refreshPromise;
+}
+
 instance.interceptors.request.use((config) => {
   if (config.url?.startsWith("/api/")) {
     config.baseURL = undefined;
@@ -62,25 +88,7 @@ instance.interceptors.response.use(
       config.headers["x-retried"] = "true";
 
       try {
-        if (!refreshPromise) {
-          refreshPromise = axios
-            .post("/api/auth/refresh", undefined, {
-              timeout: DEFAULT_ROUTE_TIMEOUT_MS,
-            })
-            .then(({ data }) => {
-              const token = data.data?.accessToken;
-              if (!token) {
-                throw new Error("Access token is missing");
-              }
-              sessionStorage.setItem("access_token", token);
-              return token;
-            })
-            .finally(() => {
-              refreshPromise = null;
-            });
-        }
-
-        const accessToken = await refreshPromise;
+        const accessToken = await refreshAccessToken();
         config.headers.Authorization = `Bearer ${accessToken}`;
         return instance(config);
       } catch (refreshError) {

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -2,9 +2,6 @@ import axios, { HttpStatusCode } from "axios";
 import { captureFeatureError } from "@/shared/lib/sentry";
 import { AUTH_ROUTES, PUBLIC_ROUTES } from "@/shared/config/routes";
 
-/** access_token 자동 재발급 인터셉터에서 제외할 인증 경로 */
-const authRoutesWithoutRefresh = Object.values(AUTH_ROUTES);
-
 export const DEFAULT_API_TIMEOUT_MS = 10 * 1000;
 export const LONG_API_TIMEOUT_MS = 30 * 1000;
 export const DEFAULT_ROUTE_TIMEOUT_MS = DEFAULT_API_TIMEOUT_MS + 2000;
@@ -28,12 +25,6 @@ export const sseInstance = axios.create({
 });
 
 let refreshPromise: Promise<string> | null = null;
-
-function redirectToSignin() {
-  if (!PUBLIC_ROUTES.some((page) => page === window.location.pathname)) {
-    window.location.replace("/signin");
-  }
-}
 
 /**
  * refresh_token 쿠키로 access_token을 재발급한다.
@@ -74,17 +65,17 @@ instance.interceptors.request.use(async (config) => {
 
   if (typeof window === "undefined") return config;
 
-  const skipAuth = authRoutesWithoutRefresh.some((path) =>
-    config.url?.includes(path),
-  );
+  let accessToken = sessionStorage.getItem("access_token");
 
-  let token = sessionStorage.getItem("access_token");
-  if (!token && !skipAuth) {
-    token = await refreshAccessToken().catch(() => null);
+  if (
+    !accessToken &&
+    !Object.values(AUTH_ROUTES).some((path) => config.url?.includes(path))
+  ) {
+    accessToken = await refreshAccessToken().catch(() => null);
   }
 
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
   }
   return config;
 });
@@ -103,7 +94,7 @@ instance.interceptors.response.use(
     if (
       error.response?.status === HttpStatusCode.Unauthorized &&
       !config.headers["x-retried"] &&
-      !authRoutesWithoutRefresh.some((path) => config.url?.includes(path))
+      !Object.values(AUTH_ROUTES).some((path) => config.url?.includes(path))
     ) {
       config.headers["x-retried"] = "true";
 
@@ -117,7 +108,11 @@ instance.interceptors.response.use(
           action: "refresh",
         });
         sessionStorage.removeItem("access_token");
-        redirectToSignin();
+
+        if (!PUBLIC_ROUTES.some((page) => page === window.location.pathname)) {
+          window.location.replace("/signin");
+        }
+
         return Promise.reject(refreshError);
       }
     }

--- a/src/shared/api/sseProxy.ts
+++ b/src/shared/api/sseProxy.ts
@@ -3,32 +3,6 @@ import axios, { HttpStatusCode } from "axios";
 import { NextRequest, NextResponse } from "next/server";
 import { serverInstance } from "@/shared/api/instance";
 
-async function getAccessToken(request: NextRequest) {
-  const queryToken = request.nextUrl.searchParams.get("accessToken");
-
-  if (queryToken) {
-    return queryToken;
-  }
-
-  return getRefreshedAccessToken(request);
-}
-
-async function getRefreshedAccessToken(request: NextRequest) {
-  const refreshToken = request.cookies.get("refresh_token")?.value;
-
-  if (!refreshToken) {
-    return null;
-  }
-
-  const reissueUrl = `${process.env.NEXT_PUBLIC_BASE_URL!}/auth/reissue`;
-
-  const { data } = await serverInstance.post(reissueUrl, {
-    refreshToken,
-  });
-
-  return data.data?.accessToken ?? data.accessToken ?? null;
-}
-
 /**
  * 업스트림 SSE 엔드포인트와의 연결을 수립합니다.
  * @param url 업스트림 SSE 절대 URL
@@ -101,7 +75,11 @@ function createSseProxyResponse(upstream: Readable, signal: AbortSignal) {
 
 /**
  * 백엔드 SSE 엔드포인트를 프록시합니다.
- * 토큰 획득 → 스트림 연결 → 401 시 토큰 재발급 재시도 → 에러/취소 처리 흐름을 공통으로 처리합니다.
+ * 토큰 검증 → 스트림 연결 → 에러/취소 처리 흐름을 공통으로 처리합니다.
+ *
+ * 토큰 재발급은 클라이언트의 공유 refreshAccessToken()(/api/auth/refresh)에 단일화한다.
+ * 프록시는 reissue하지 않으며, access token이 없거나 업스트림 401이면 그대로 401을
+ * 반환해 클라이언트가 새 토큰으로 재연결하도록 한다.
  * @param request
  * @param upstreamPath NEXT_PUBLIC_BASE_URL 기준 업스트림 경로 (예: "/dormitory/music/subscribe")
  */
@@ -113,7 +91,7 @@ export async function proxySse(request: NextRequest, upstreamPath: string) {
   const upstreamUrl = `${process.env.NEXT_PUBLIC_BASE_URL!}${upstreamPath}`;
 
   try {
-    const accessToken = await getAccessToken(request);
+    const accessToken = request.nextUrl.searchParams.get("accessToken");
 
     if (!accessToken) {
       return NextResponse.json(
@@ -122,44 +100,15 @@ export async function proxySse(request: NextRequest, upstreamPath: string) {
       );
     }
 
-    try {
-      const response = await getSseStream(
-        upstreamUrl,
-        accessToken,
-        request.signal,
-      );
+    const response = await getSseStream(
+      upstreamUrl,
+      accessToken,
+      request.signal,
+    );
 
-      return createSseProxyResponse(response.data, request.signal);
-    } catch (error) {
-      console.error("[SSE] 최초 SSE 연결 실패");
-
-      if (
-        !axios.isAxiosError(error) ||
-        error.response?.status !== HttpStatusCode.Unauthorized
-      ) {
-        throw error;
-      }
-
-      const refreshedAccessToken = await getRefreshedAccessToken(request);
-
-      if (!refreshedAccessToken) {
-        throw error;
-      }
-
-      if (request.signal.aborted) {
-        return new Response(null, { status: HttpStatusCode.NoContent });
-      }
-
-      const response = await getSseStream(
-        upstreamUrl,
-        refreshedAccessToken,
-        request.signal,
-      );
-
-      return createSseProxyResponse(response.data, request.signal);
-    }
+    return createSseProxyResponse(response.data, request.signal);
   } catch (error) {
-    console.error("[SSE] 최종 에러");
+    console.error("[SSE] 연결 실패");
 
     if (axios.isAxiosError(error) && error.code === "ERR_CANCELED") {
       return new Response(null, { status: HttpStatusCode.NoContent });

--- a/src/shared/api/sseProxy.ts
+++ b/src/shared/api/sseProxy.ts
@@ -1,31 +1,7 @@
 import { Readable } from "node:stream";
 import axios, { HttpStatusCode } from "axios";
 import { NextRequest, NextResponse } from "next/server";
-import { serverInstance } from "@/shared/api/instance";
-
-/**
- * 업스트림 SSE 엔드포인트와의 연결을 수립합니다.
- * @param url 업스트림 SSE 절대 URL
- * @param accessToken
- * @param signal
- * @returns AxiosResponse
- */
-async function getSseStream(
-  url: string,
-  accessToken: string,
-  signal?: AbortSignal,
-) {
-  // SSE는 무제한 연결이므로 자동 연결 끊김 방지를 위해 timeout 0을 사용합니다.
-  return serverInstance.get(url, {
-    headers: {
-      Accept: "text/event-stream",
-      Authorization: `Bearer ${accessToken}`,
-    },
-    responseType: "stream",
-    timeout: 0,
-    signal,
-  });
-}
+import { sseInstance } from "@/shared/api/instance";
 
 /**
  * Node.js가 전송하는 데이터(청크 = 버퍼(타입: Uint8Array)를) 브라우저 표준 ReadableStream으로 변환합니다.
@@ -100,11 +76,10 @@ export async function proxySse(request: NextRequest, upstreamPath: string) {
       );
     }
 
-    const response = await getSseStream(
-      upstreamUrl,
-      accessToken,
-      request.signal,
-    );
+    const response = await sseInstance.get(upstreamUrl, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: request.signal,
+    });
 
     return createSseProxyResponse(response.data, request.signal);
   } catch (error) {

--- a/src/shared/api/sseProxy.ts
+++ b/src/shared/api/sseProxy.ts
@@ -56,6 +56,7 @@ function createSseProxyResponse(upstream: Readable, signal: AbortSignal) {
  * 토큰 재발급은 클라이언트의 공유 refreshAccessToken()(/api/auth/refresh)에 단일화한다.
  * 프록시는 reissue하지 않으며, access token이 없거나 업스트림 401이면 그대로 401을
  * 반환해 클라이언트가 새 토큰으로 재연결하도록 한다.
+ * access token은 Authorization 헤더(Bearer)로 전달받는다.
  * @param request
  * @param upstreamPath NEXT_PUBLIC_BASE_URL 기준 업스트림 경로 (예: "/dormitory/music/subscribe")
  */
@@ -67,7 +68,10 @@ export async function proxySse(request: NextRequest, upstreamPath: string) {
   const upstreamUrl = `${process.env.NEXT_PUBLIC_BASE_URL!}${upstreamPath}`;
 
   try {
-    const accessToken = request.nextUrl.searchParams.get("accessToken");
+    const authorization = request.headers.get("authorization");
+    const accessToken = authorization?.startsWith("Bearer ")
+      ? authorization.slice("Bearer ".length)
+      : null;
 
     if (!accessToken) {
       return NextResponse.json(

--- a/src/shared/config/cookie.ts
+++ b/src/shared/config/cookie.ts
@@ -1,0 +1,12 @@
+export const COOKIE_CONFIG = {
+  refreshToken: {
+    name: "refresh_token",
+    options: {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      maxAge: 60 * 60 * 24 * 14,
+      path: "/",
+      sameSite: "lax" as const,
+    },
+  },
+};

--- a/src/shared/config/routes.ts
+++ b/src/shared/config/routes.ts
@@ -5,3 +5,13 @@ export const ROUTES = [
   { href: "/club", label: "동아리" },
   { href: "/students", label: "학생관리" },
 ] as const;
+
+/** 인증 없이 접근 가능한 페이지 (proxy 보호 예외) */
+export const PUBLIC_ROUTES = ["/signin", "/callback"] as const;
+
+/** 인증 관련 라우트 핸들러 경로 */
+export const AUTH_ROUTES = {
+  callback: "/api/auth/callback",
+  refresh: "/api/auth/refresh",
+  signout: "/api/auth/signout",
+} as const;


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- refresh token 회전 경쟁으로 세션 복구가 실패하던 문제 수정: `sseProxy`가 SSE용 토큰을 얻으려 독립적으로 reissue하며 회전된 refresh token을 버려 쿠키가 무효화되던 원인 제거 — 프록시는 더 이상 reissue하지 않고 클라이언트가 전달한 access token만 사용
- 토큰 재발급을 클라이언트 공유 `refreshAccessToken()`(`/api/auth/refresh`) 한 곳으로 단일화하고, 요청 인터셉터·응답 401 복구·SSE가 동일한 단일 refresh 프로미스를 공유하도록 정리
- 진입 세션 복구를 **요청 레벨 대기**로 재설계: 요청 인터셉터가 `access_token`이 없으면 공유 refresh에 합류해 토큰이 준비된 뒤 요청을 보냄 → 진입 시 401 폭포 제거, 화면 렌더링에는 무영향 (별도 `SessionRestorer` 컴포넌트 제거)
- 인증 SSE를 `eventsource` 라이브러리로 전환: 재연결마다 호출되는 `fetch`에 sessionStorage의 최신 `access_token`을 **Authorization 헤더**로 주입(URL 쿼리 토큰 노출 제거), 401이면 공유 refresh로 1회 재시도, 네트워크 드롭 재연결·Last-Event-ID는 라이브러리에 위임(핸드롤 재연결·지수 백오프 로직 제거)
- SSE 프록시는 `Authorization` 헤더에서 토큰을 읽도록 변경(프록시 reissue 없음 유지)
- 쿠키 옵션과 인증 라우트 경로를 공통 설정으로 추출(`COOKIE_CONFIG`, `PUBLIC_ROUTES`/`AUTH_ROUTES`)해 라우트 핸들러·proxy·호출부에서 재사용

## 💬리뷰 요구사항

- 세션 스토리지의 `access_token` 삭제 후 새로고침 시 401 없이 정상 복구되고 로그인 페이지로 튕기지 않는지 확인
- 진입 직후 여러 요청이 동시에 떠도 `/api/auth/refresh`가 1회만 호출되는지 확인
- 기상음악·자습 출석 SSE 실시간 갱신, 그리고 토큰 만료 중 재연결 시 토큰이 갱신되어 복구되는지 확인
- SSE 재연결 간격이 고정 3초(지수 백오프 미적용)인 점 확인 — 필요 시 백엔드 `retry:` 필드로 조정 가능