### PR TITLE
feat: 급식표에 끼니별 칼로리 표시

### DIFF
--- a/src/widgets/main/ui/MealCard.tsx
+++ b/src/widgets/main/ui/MealCard.tsx
@@ -94,10 +94,10 @@ function MealCardContent({ dateStr, selectedTab }: MealCardContentProps) {
   const calories = selectedMeal?.calories?.trim();
 
   return (
-    <div className="flex flex-1 flex-col overflow-y-auto">
+    <div className="flex min-h-0 flex-1 flex-col">
       {menuItems.length > 0 ? (
         <>
-          <ul className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:flex lg:flex-col lg:gap-3">
+          <ul className="grid min-h-0 flex-1 grid-cols-1 gap-x-6 gap-y-3 overflow-y-auto sm:grid-cols-2 lg:flex lg:flex-col lg:gap-3">
             {menuItems.map((item, index) => (
               <li
                 key={`${item}-${index}`}
@@ -108,7 +108,7 @@ function MealCardContent({ dateStr, selectedTab }: MealCardContentProps) {
             ))}
           </ul>
           {calories && (
-            <p className="border-sub-4 text-text-3 text-sub-2 mt-auto border-t pt-3 font-medium">
+            <p className="border-sub-4 text-text-3 text-sub-2 mt-3 shrink-0 border-t pt-3 font-medium">
               총 {calories}
             </p>
           )}

--- a/src/widgets/main/ui/MealCard.tsx
+++ b/src/widgets/main/ui/MealCard.tsx
@@ -91,20 +91,28 @@ function MealCardContent({ dateStr, selectedTab }: MealCardContentProps) {
     (m) => m.mealType === MEAL_TYPE_MAP[selectedTab],
   );
   const menuItems = selectedMeal?.menus ?? [];
+  const calories = selectedMeal?.calories?.trim();
 
   return (
     <div className="flex flex-1 flex-col overflow-y-auto">
       {menuItems.length > 0 ? (
-        <ul className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:flex lg:flex-col lg:gap-3">
-          {menuItems.map((item, index) => (
-            <li
-              key={`${item}-${index}`}
-              className="text-text-1 text-sub-1 font-semibold"
-            >
-              {item}
-            </li>
-          ))}
-        </ul>
+        <>
+          <ul className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:flex lg:flex-col lg:gap-3">
+            {menuItems.map((item, index) => (
+              <li
+                key={`${item}-${index}`}
+                className="text-text-1 text-sub-1 font-semibold"
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+          {calories && (
+            <p className="border-sub-4 text-text-3 text-sub-2 mt-auto border-t pt-3 font-medium">
+              총 {calories}
+            </p>
+          )}
+        </>
       ) : (
         <MealCard.Empty />
       )}


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 급식표 카드에서 선택한 끼니의 총 칼로리를 표시
- 메뉴 목록만 스크롤되고, 칼로리 줄은 카드 하단에 고정되어 항상 보이도록 처리
- 칼로리 값이 없거나 빈 문자열인 경우 표시하지 않도록 처리

<img width="630" height="996" alt="2026-06-11_02-08-29" src="https://github.com/user-attachments/assets/12ae0fd9-a74d-4cbc-a597-3a1bade67bbd" />
