### PR TITLE
fix: 릴리즈 드래프트 댓글 회신 GH_REPO 누락 문제 수정

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -57,6 +57,7 @@ jobs:
         if: github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
           DRAFT_URL: ${{ steps.draft.outputs.html_url }}
         run: |


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- Release Drafter 워크플로우의 draft 링크 회신 스텝이 `gh pr comment` 실행 시 `fatal: not a git repository`로 실패하던 문제를 수정했습니다.
- 해당 job에는 checkout이 없어 `gh`가 대상 저장소를 알 수 없었습니다. `GH_REPO` 환경변수(`${{ github.repository }}`)를 추가해 checkout 없이도 저장소를 특정하도록 했습니다.
- release-drafter 본 동작(draft 생성)은 정상이었고, 이번 수정은 회신 댓글 스텝에만 영향을 줍니다.

## 💬리뷰 요구사항

- `issue_comment` 트리거 특성상 이 수정은 `main`(기본 브랜치)에 도달한 뒤 다음 실행부터 적용됩니다.