### PR TITLE
v2026.0611.1017

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -57,6 +57,7 @@ jobs:
         if: github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
           DRAFT_URL: ${{ steps.draft.outputs.html_url }}
         run: |


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 릴리즈 드래프트 댓글 회신이 `gh pr comment` 실행 시 저장소 컨텍스트 부재(`not a git repository`)로 실패하던 문제를 수정했습니다. `GH_REPO` 환경변수를 추가해 checkout 없이도 대상 저장소를 특정합니다. (#180)
