### PR TITLE
fix: SSE 구독을 레이아웃으로 올려 재구독 폭주 제거

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -7,6 +7,7 @@ import { Header } from "@/widgets/header/ui/header";
 import { AiChatButton } from "@/features/ai-chat/ui/AiChatButton";
 import { AiChatModal } from "@/features/ai-chat/ui/AiChatModal";
 import { useAiChatPanel } from "@/features/ai-chat/model/useAiChatPanel";
+import { RealtimeSubscriptions } from "@/widgets/realtime-subscription/ui/RealtimeSubscriptions";
 
 export default function MainLayout({
   children,
@@ -18,6 +19,7 @@ export default function MainLayout({
 
   return (
     <div className="bg-background flex h-dvh overflow-hidden">
+      <RealtimeSubscriptions />
       <div className="hidden sm:flex">
         <Sidebar />
       </div>

--- a/src/features/self-study/ui/SelfStudySection.tsx
+++ b/src/features/self-study/ui/SelfStudySection.tsx
@@ -20,7 +20,6 @@ import { useStudyFilter } from "../model/useStudyFilter";
 import { useApplyStudy } from "../model/useApplyStudy";
 import { useCancelStudy } from "../model/useCancelStudy";
 import { useCheckStudyAttendance } from "../model/useCheckStudyAttendance";
-import { useStudyAttendanceSubscription } from "../model/useStudyAttendanceSubscription";
 import { useUncheckStudyAttendance } from "../model/useUncheckStudyAttendance";
 import { NoteText } from "@/shared/ui/NoteText";
 import { StudyApplicantCard } from "./StudyApplicantCard";
@@ -60,7 +59,6 @@ export function SelfStudySection() {
   });
   const studyPermission = createStudyPermission({ role: user?.role });
 
-  useStudyAttendanceSubscription(user?.role);
   const checkAttendanceMutation = useCheckStudyAttendance();
   const uncheckAttendanceMutation = useUncheckStudyAttendance();
 

--- a/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
+++ b/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
@@ -12,7 +12,6 @@ import { MusicRecommendModal } from "@/features/wake-up-music/ui/MusicRecommendM
 import { MusicListModal } from "@/features/wake-up-music/ui/MusicListModal";
 import { MusicRecommendButton } from "@/features/wake-up-music/ui/MusicRecommendButton";
 import { useWakeUpMusic } from "@/features/wake-up-music/model/useWakeUpMusic";
-import { useWakeUpMusicSubscription } from "@/features/wake-up-music/model/useWakeUpMusicSubscription";
 import { MusicFilterDropdown } from "@/features/wake-up-music/ui/MusicFilterDropdown";
 import { useMusicFilter } from "@/features/wake-up-music/model/useMusicFilter";
 
@@ -49,8 +48,6 @@ export function WakeUpMusicSection({
     likeMutation,
     cancelMutation,
   } = useWakeUpMusic(filterParams);
-
-  useWakeUpMusicSubscription();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isListModalOpen, setIsListModalOpen] = useState(false);

--- a/src/widgets/realtime-subscription/ui/RealtimeSubscriptions.tsx
+++ b/src/widgets/realtime-subscription/ui/RealtimeSubscriptions.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { userQueries } from "@/entities/user/api/userQueries";
+import { useWakeUpMusicSubscription } from "@/features/wake-up-music/model/useWakeUpMusicSubscription";
+import { useStudyAttendanceSubscription } from "@/features/self-study/model/useStudyAttendanceSubscription";
+
+export function RealtimeSubscriptions() {
+  const { data: me } = useQuery(userQueries.me());
+
+  useWakeUpMusicSubscription();
+  useStudyAttendanceSubscription(me?.role);
+
+  return null;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 기상음악·자습 출석 SSE 구독을 페이지 섹션에서 분리해 (main) 레이아웃에서 세션당 한 번만 구독하도록 변경
- 페이지 전환마다 EventSource를 재연결하던 churn을 제거해 구독 요청량을 크게 줄임
- RealtimeSubscriptions 위젯을 추가하고 WakeUpMusicSection·SelfStudySection의 구독 호출 제거

### 전체 24k 이벤트 중 23k를 차지

<img width="1530" height="572" alt="image" src="https://github.com/user-attachments/assets/a211a7b4-7c91-4ac8-9f3b-e7611f108c61" />

## 💬리뷰 요구사항

- 구독이 모든 (main) 페이지에서 세션 내내 유지됩니다. 다수 동시 연결을 견디도록 [broadcast 비블로킹 개선](https://github.com/team-incube/Flooding-Server-V2/pull/199)과 함께 배포되어야 합니다.