### PR TITLE
fix: Sentry 터널 경로 인증 리다이렉트로 인한 405 방지

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -4,13 +4,9 @@ import { PUBLIC_ROUTES } from "@/shared/config/routes";
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|api|images|video|files).*)",
+    "/((?!_next/static|_next/image|favicon.ico|api|monitoring|images|video|files).*)",
   ],
 };
-
-function isSafeRedirectPath(path: string): boolean {
-  return path.startsWith("/") && !path.startsWith("//") && path !== "/signin";
-}
 
 /**
  * 링크 미리보기·검색 색인을 위한 소셜/SEO 크롤러 User-Agent.
@@ -21,12 +17,10 @@ function isSafeRedirectPath(path: string): boolean {
 const CRAWLER_USER_AGENT_PATTERN =
   /facebookexternalhit|facebot|twitterbot|slackbot|slack-imgproxy|discordbot|kakaotalk-scrap|daumoa|telegrambot|whatsapp|linkedinbot|redditbot|pinterest|applebot|googlebot|bingbot|yeti|naverbot|line-podcast|skypeuripreview|embedly|google-inspectiontool/i;
 
-function isCrawler(userAgent: string | null): boolean {
-  return userAgent ? CRAWLER_USER_AGENT_PATTERN.test(userAgent) : false;
-}
-
 export function proxy(request: NextRequest) {
-  if (isCrawler(request.headers.get("user-agent"))) {
+  const userAgent = request.headers.get("user-agent");
+
+  if (userAgent && CRAWLER_USER_AGENT_PATTERN.test(userAgent)) {
     return NextResponse.next();
   }
 
@@ -38,7 +32,12 @@ export function proxy(request: NextRequest) {
   if (pathname === "/signin" && refreshToken) {
     const redirectTo = searchParams.get("redirectTo");
 
-    if (redirectTo && isSafeRedirectPath(redirectTo)) {
+    if (
+      redirectTo &&
+      redirectTo.startsWith("/") &&
+      !redirectTo.startsWith("//") &&
+      redirectTo !== "/signin"
+    ) {
       return NextResponse.redirect(new URL(redirectTo, request.url));
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 비인증 상태(로그인 진행 중)에서 Sentry 터널 POST(`/monitoring`)가 인증 가드에 걸려 `/signin`으로 307 리다이렉트되며 POST 메서드가 유지돼 405가 발생하던 문제를 해결합니다.
- proxy `matcher`의 제외 목록에 `monitoring`을 추가해 Sentry 터널 경로가 인증 프록시를 거치지 않도록 합니다.
- `isSafeRedirectPath`, `isCrawler` 헬퍼를 호출부에 인라인 정리합니다.

## 💬리뷰 요구사항

- 로그아웃 상태에서 Sentry 이벤트 발생 시 `/monitoring` POST가 더 이상 `/signin`으로 리다이렉트되지 않는지 확인 부탁드립니다.