### PR TITLE
fix: 홈베이스 예약 조회 API date 쿼리 파라미터 대응

### DIFF
--- a/src/entities/homebase/api/getHomebase.ts
+++ b/src/entities/homebase/api/getHomebase.ts
@@ -5,9 +5,11 @@ type HomebaseResponse =
   | HomebaseReservation[]
   | { data?: HomebaseReservation[] };
 
-export async function getHomebaseReservations(): Promise<
-  HomebaseReservation[]
-> {
-  const { data } = await instance.get<HomebaseResponse>("/homebase");
+export async function getHomebaseReservations(
+  date: string,
+): Promise<HomebaseReservation[]> {
+  const { data } = await instance.get<HomebaseResponse>("/homebase", {
+    params: { date },
+  });
   return Array.isArray(data) ? data : (data.data ?? []);
 }

--- a/src/entities/homebase/api/homebaseQueries.ts
+++ b/src/entities/homebase/api/homebaseQueries.ts
@@ -4,10 +4,10 @@ import { getHomebaseReservations } from "@/entities/homebase/api/getHomebase";
 import type { HomebaseApplyRequest } from "@/entities/homebase/model/homebase";
 
 export const homebaseQueries = {
-  list: () =>
+  list: (date: string) =>
     queryOptions({
-      queryKey: ["homebase", "list"],
-      queryFn: getHomebaseReservations,
+      queryKey: ["homebase", "list", date],
+      queryFn: () => getHomebaseReservations(date),
     }),
 } as const;
 

--- a/src/entities/homebase/model/homebase.ts
+++ b/src/entities/homebase/model/homebase.ts
@@ -5,6 +5,7 @@ export interface HomebaseMember {
 
 export interface HomebaseReservation {
   id: number;
+  reservationDate: string;
   startPeriod: number;
   endPeriod: number;
   homebaseId: number;

--- a/src/features/homebase/model/useHomebaseReservation.ts
+++ b/src/features/homebase/model/useHomebaseReservation.ts
@@ -35,6 +35,7 @@ export function useHomebaseReservation() {
     myReservationIds,
     isError,
   } = useHomebaseReservationData({
+    reservationDate,
     selectedFloor,
     selectedStartNum,
     selectedEndNum,

--- a/src/features/homebase/model/useHomebaseReservationActions.ts
+++ b/src/features/homebase/model/useHomebaseReservationActions.ts
@@ -80,7 +80,7 @@ export function useHomebaseReservationActions({
     }) => homebaseMutations.apply(homebaseId, body),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: homebaseQueries.list().queryKey,
+        queryKey: homebaseQueries.list(reservationDate).queryKey,
       });
       onApplySuccess();
       toast.success("홈베이스 신청이 완료되었습니다");
@@ -93,7 +93,7 @@ export function useHomebaseReservationActions({
       homebaseMutations.cancel(reservationId),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: homebaseQueries.list().queryKey,
+        queryKey: homebaseQueries.list(reservationDate).queryKey,
       });
       toast.success("예약이 취소되었습니다");
     },

--- a/src/features/homebase/model/useHomebaseReservationData.ts
+++ b/src/features/homebase/model/useHomebaseReservationData.ts
@@ -11,12 +11,14 @@ import {
 } from "@/features/homebase/lib/homebaseReservationPolicy";
 
 interface UseHomebaseReservationDataParams {
+  reservationDate: string;
   selectedFloor: string;
   selectedStartNum: number;
   selectedEndNum: number;
 }
 
 export function useHomebaseReservationData({
+  reservationDate,
   selectedFloor,
   selectedStartNum,
   selectedEndNum,
@@ -26,7 +28,7 @@ export function useHomebaseReservationData({
     data: reservations = [],
     isLoading,
     isError,
-  } = useQuery(homebaseQueries.list());
+  } = useQuery(homebaseQueries.list(reservationDate));
   const reservedTables = getReservedTableMembers({
     reservations,
     selectedFloor,


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

서버 홈베이스 예약 조회 API 스펙 변경에 맞춰 프론트 코드를 수정했습니다.

**변경된 서버 API**
- `GET /homebase` → `GET /homebase?date=LocalDate`

**수정 내용**
- `HomebaseReservation` 타입에 `reservationDate` 필드 추가
- `getHomebaseReservations`에 `date` 쿼리 파라미터 전달
- `homebaseQueries.list(date)` 시그니처 변경 및 queryKey에 date 포함
- `useHomebaseReservationData` → `useHomebaseReservation` → `useHomebaseReservationActions` 순으로 `reservationDate` 전달

## 💬리뷰 요구사항(선택)
