### PR TITLE
feat: 기상음악 추천 UX 개선 및 로딩 연출 추가

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -7,6 +7,7 @@ import { Header } from "@/widgets/header/ui/header";
 import { AiChatButton } from "@/features/ai-chat/ui/AiChatButton";
 import { AiChatModal } from "@/features/ai-chat/ui/AiChatModal";
 import { useAiChatPanel } from "@/features/ai-chat/model/useAiChatPanel";
+import { WakeUpMusicRecommend } from "@/features/wake-up-music/ui/WakeUpMusicRecommend";
 import { RealtimeSubscriptions } from "@/widgets/realtime-subscription/ui/RealtimeSubscriptions";
 
 export default function MainLayout({
@@ -32,6 +33,7 @@ export default function MainLayout({
       </div>
       <SidebarDrawer isOpen={isOpen} onClose={close} />
       {!chat.isOpen && <AiChatButton onClick={chat.open} />}
+      <WakeUpMusicRecommend className="fixed right-6 bottom-22 z-30 lg:hidden" />
     </div>
   );
 }

--- a/src/entities/music/api/youtubeQueries.ts
+++ b/src/entities/music/api/youtubeQueries.ts
@@ -15,6 +15,7 @@ interface YoutubeVideosResponse {
 
 export async function getYoutubeVideos(
   videoIds: string[],
+  signal?: AbortSignal,
 ): Promise<Record<string, YoutubeVideoMetadata>> {
   const ids = Array.from(new Set(videoIds)).filter(Boolean);
 
@@ -27,6 +28,7 @@ export async function getYoutubeVideos(
     {
       baseURL: undefined,
       params: { ids: ids.join(",") },
+      signal,
     },
   );
 
@@ -39,7 +41,7 @@ export const youtubeQueries = {
 
     return queryOptions({
       queryKey: ["music", "youtube-videos", ids.join(",")],
-      queryFn: () => getYoutubeVideos(ids),
+      queryFn: ({ signal }) => getYoutubeVideos(ids, signal),
       enabled: ids.length > 0,
     });
   },

--- a/src/features/wake-up-music/model/useAiMusicRecommend.ts
+++ b/src/features/wake-up-music/model/useAiMusicRecommend.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import axios, { HttpStatusCode } from "axios";
 import { toast } from "sonner";
@@ -11,7 +11,7 @@ import { youtubeQueries } from "@/entities/music/api/youtubeQueries";
 const MAX_RETRY = 3;
 type RecommendEmptyReason = "NO_HISTORY" | "NO_RECOMMENDATIONS";
 
-export function useAiMusicRecommend(enabled: boolean) {
+export function useAiMusicRecommend() {
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
   const [youtubeLinks, setYoutubeLinks] = useState<string[]>([]);
@@ -71,19 +71,15 @@ export function useAiMusicRecommend(enabled: boolean) {
     },
   });
 
-  useEffect(() => {
-    if (enabled) {
-      recommendMusic();
-    }
-  }, [enabled, recommendMusic]);
-
   const videoIds = youtubeLinks
     .map(extractYoutubeVideoId)
     .filter((id): id is string => Boolean(id));
 
-  const { data: youtubeVideos = {} } = useQuery(
+  const { data: youtubeVideos = {}, isFetching: isYoutubeFetching } = useQuery(
     youtubeQueries.videos(videoIds),
   );
+
+  const isLoading = isPending || (videoIds.length > 0 && isYoutubeFetching);
 
   const displayCards = youtubeLinks.map((url) => {
     const id = extractYoutubeVideoId(url) ?? "";
@@ -92,6 +88,7 @@ export function useAiMusicRecommend(enabled: boolean) {
       url,
       title: meta?.title ?? "",
       thumbnailUrl: meta?.thumbnailUrl ?? "",
+      durationText: meta?.durationText ?? "",
     };
   });
 
@@ -113,7 +110,7 @@ export function useAiMusicRecommend(enabled: boolean) {
     retryCount,
     maxRetry: MAX_RETRY,
     isActive: selectedUrl !== null,
-    isPending,
+    isPending: isLoading,
     handleSelect,
     handleRetry,
   };

--- a/src/features/wake-up-music/model/useAiMusicRecommend.ts
+++ b/src/features/wake-up-music/model/useAiMusicRecommend.ts
@@ -80,6 +80,11 @@ export function useAiMusicRecommend() {
   );
 
   const isLoading = isPending || (videoIds.length > 0 && isYoutubeFetching);
+  const loadingStage: "recommend" | "youtube" | null = isPending
+    ? "recommend"
+    : videoIds.length > 0 && isYoutubeFetching
+      ? "youtube"
+      : null;
 
   const displayCards = youtubeLinks.map((url) => {
     const id = extractYoutubeVideoId(url) ?? "";
@@ -97,6 +102,7 @@ export function useAiMusicRecommend() {
   };
 
   const handleRetry = () => {
+    if (isLoading) return;
     if (retryCount < MAX_RETRY) {
       setRetryCount((prev) => prev + 1);
       recommendMusic();
@@ -111,6 +117,7 @@ export function useAiMusicRecommend() {
     maxRetry: MAX_RETRY,
     isActive: selectedUrl !== null,
     isPending: isLoading,
+    loadingStage,
     handleSelect,
     handleRetry,
   };

--- a/src/features/wake-up-music/model/useAiMusicRecommend.ts
+++ b/src/features/wake-up-music/model/useAiMusicRecommend.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios, { HttpStatusCode } from "axios";
 import { toast } from "sonner";
 import { aiMutations } from "@/entities/ai/api/aiMutations";
@@ -12,6 +12,7 @@ const MAX_RETRY = 3;
 type RecommendEmptyReason = "NO_HISTORY" | "NO_RECOMMENDATIONS";
 
 export function useAiMusicRecommend() {
+  const queryClient = useQueryClient();
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
   const [youtubeLinks, setYoutubeLinks] = useState<string[]>([]);
@@ -19,9 +20,16 @@ export function useAiMusicRecommend() {
     null,
   );
 
+  const videoIds = youtubeLinks
+    .map(extractYoutubeVideoId)
+    .filter((id): id is string => Boolean(id));
+
   const { mutate: recommendMusic, isPending } = useMutation({
     ...aiMutations.recommendSong(),
     onMutate: () => {
+      queryClient.cancelQueries({
+        queryKey: youtubeQueries.videos(videoIds).queryKey,
+      });
       setYoutubeLinks([]);
       setSelectedUrl(null);
       setEmptyReason(null);
@@ -70,10 +78,6 @@ export function useAiMusicRecommend() {
       toast.error("AI 노래 추천에 실패했습니다.");
     },
   });
-
-  const videoIds = youtubeLinks
-    .map(extractYoutubeVideoId)
-    .filter((id): id is string => Boolean(id));
 
   const { data: youtubeVideos = {}, isFetching: isYoutubeFetching } = useQuery(
     youtubeQueries.videos(videoIds),

--- a/src/features/wake-up-music/model/useApplyRecommendedMusic.ts
+++ b/src/features/wake-up-music/model/useApplyRecommendedMusic.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { HttpStatusCode } from "axios";
+import { toast } from "sonner";
+import { dormitoryMutations } from "@/entities/dormitory/api/dormitoryQueries";
+
+export function useApplyRecommendedMusic() {
+  const queryClient = useQueryClient();
+
+  const applyRecommendedMutation = useMutation({
+    ...dormitoryMutations.applyMusic(),
+    mutationKey: ["dormitory", "music-apply-recommended"],
+    meta: {
+      getExtras: (body: { musicUrl: string }) => ({ musicUrl: body.musicUrl }),
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["dormitory", "music"] });
+    },
+    onError: (error) => {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined;
+
+      if (status === HttpStatusCode.Conflict) {
+        toast.error("이미 기상음악을 신청했습니다.");
+        return;
+      }
+      toast.error("기상음악 신청에 실패했습니다.");
+    },
+  });
+
+  const handleSubmitRecommendedMusic = async (selectedUrl: string) => {
+    await applyRecommendedMutation.mutateAsync({ musicUrl: selectedUrl });
+  };
+
+  return { handleSubmitRecommendedMusic };
+}

--- a/src/features/wake-up-music/model/useWakeUpMusic.ts
+++ b/src/features/wake-up-music/model/useWakeUpMusic.ts
@@ -78,35 +78,9 @@ export function useWakeUpMusic(filterParams?: DormitoryMusicQueryParams) {
     },
   });
 
-  const applyRecommendedMutation = useMutation({
-    ...dormitoryMutations.applyMusic(),
-    mutationKey: ["dormitory", "music-apply-recommended"],
-    meta: {
-      getExtras: (body: { musicUrl: string }) => ({ musicUrl: body.musicUrl }),
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: musicQuery.queryKey });
-    },
-    onError: (error) => {
-      const status = axios.isAxiosError(error)
-        ? error.response?.status
-        : undefined;
-
-      if (status === HttpStatusCode.Conflict) {
-        toast.error("이미 기상음악을 신청했습니다.");
-        return;
-      }
-      toast.error("기상음악 신청에 실패했습니다.");
-    },
-  });
-
   const handleApplyMusic = () => {
     if (!canApply || applyMutation.isPending) return;
     applyMutation.mutate();
-  };
-
-  const handleSubmitRecommendedMusic = async (selectedUrl: string) => {
-    await applyRecommendedMutation.mutateAsync({ musicUrl: selectedUrl });
   };
 
   const likeMutation = useMutation({
@@ -193,7 +167,6 @@ export function useWakeUpMusic(filterParams?: DormitoryMusicQueryParams) {
     canDeleteAnyMusic,
     applyMutation,
     handleApplyMusic,
-    handleSubmitRecommendedMusic,
     likeMutation,
     cancelMutation,
   };

--- a/src/features/wake-up-music/model/useWakeUpMusic.ts
+++ b/src/features/wake-up-music/model/useWakeUpMusic.ts
@@ -17,6 +17,8 @@ import { todayKst } from "@/shared/lib/kst";
 import { createMusicPermission } from "@/entities/dormitory/lib/musicPermission";
 import { getInitialMusicDate } from "@/features/wake-up-music/lib/date";
 import { musicUrlSchema } from "@/features/wake-up-music/lib/wakeUpMusicSchema";
+import { extractYoutubeVideoId } from "@/entities/music/lib/youtube";
+import { youtubeQueries } from "@/entities/music/api/youtubeQueries";
 
 export function useWakeUpMusic(filterParams?: DormitoryMusicQueryParams) {
   const queryClient = useQueryClient();
@@ -31,6 +33,27 @@ export function useWakeUpMusic(filterParams?: DormitoryMusicQueryParams) {
 
   const { data: songs = [] } = useQuery(musicQuery);
   const { data: me } = useQuery(userQueries.me());
+
+  const videoIds = songs
+    .map((music) => extractYoutubeVideoId(music.videoUrl ?? music.musicUrl))
+    .filter((id): id is string => Boolean(id));
+
+  const { data: youtubeVideos = {} } = useQuery(
+    youtubeQueries.videos(videoIds),
+  );
+
+  const enrichedSongs = songs.map((music) => {
+    const videoId = extractYoutubeVideoId(music.videoUrl ?? music.musicUrl);
+    const meta = videoId ? youtubeVideos[videoId] : undefined;
+
+    if (!meta) return music;
+
+    return {
+      ...music,
+      duration: music.duration ?? meta.duration,
+      durationText: music.durationText ?? meta.durationText,
+    };
+  });
 
   const applyMutation = useMutation({
     mutationKey: dormitoryMutations.applyMusic().mutationKey,
@@ -165,7 +188,7 @@ export function useWakeUpMusic(filterParams?: DormitoryMusicQueryParams) {
     isToday,
     selectedDate,
     setSelectedDate,
-    songs,
+    songs: enrichedSongs,
     me,
     canDeleteAnyMusic,
     applyMutation,

--- a/src/features/wake-up-music/ui/MusicRecommendCard.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendCard.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import Checkbox from "@/shared/asset/svg/Checkbox";
+import CheckCircle from "@/shared/asset/svg/CheckCircle";
 import Image from "next/image";
 
 interface MusicRecommendCardProps {
   title: string;
   thumbnailUrl: string;
+  durationText?: string;
   checked: boolean;
   onChange: () => void;
 }
@@ -13,6 +15,7 @@ interface MusicRecommendCardProps {
 export default function MusicRecommendCard({
   title,
   thumbnailUrl,
+  durationText,
   checked,
   onChange,
 }: MusicRecommendCardProps) {
@@ -31,9 +34,21 @@ export default function MusicRecommendCard({
           />
         )}
 
-        <div className="absolute top-2 right-2">
+        <div className="absolute top-2 right-2 z-20">
           <Checkbox isActive={checked} />
         </div>
+
+        {checked && (
+          <div className="bg-background/80 absolute inset-0 z-10 flex items-center justify-center rounded-xl">
+            <CheckCircle />
+          </div>
+        )}
+
+        {durationText && (
+          <span className="text-caption-3 absolute right-2 bottom-2 line-clamp-1 rounded bg-black/70 px-1.5 py-0.5 text-white">
+            {durationText}
+          </span>
+        )}
       </div>
 
       <div className="text-text-3 text-main-text mt-2 truncate">{title}</div>

--- a/src/features/wake-up-music/ui/MusicRecommendLoading.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendLoading.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import VinylRecord from "@/shared/asset/svg/VinylRecord";
+import Chatbot from "@/shared/asset/svg/Chatbot";
+
+interface MusicRecommendLoadingProps {
+  stage: "recommend" | "youtube";
+}
+
+const stageMessage = {
+  recommend: "AI가 곡을 고르고 있어요",
+  youtube: "영상 정보를 불러오고 있어요",
+} as const;
+
+export function MusicRecommendLoading({ stage }: MusicRecommendLoadingProps) {
+  return (
+    <div className="flex min-h-[230px] w-full flex-col items-center justify-center gap-5">
+      <div className="relative grid animate-spin place-items-center motion-reduce:animate-none">
+        <VinylRecord size={104} />
+        <span className="pointer-events-none absolute block size-9">
+          <Chatbot />
+        </span>
+      </div>
+      <p className="text-text-2 text-main-text">{stageMessage[stage]}</p>
+    </div>
+  );
+}

--- a/src/features/wake-up-music/ui/MusicRecommendModal.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendModal.tsx
@@ -62,7 +62,7 @@ export function MusicRecommendModal({
     isPending,
     handleSelect,
     handleRetry,
-  } = useAiMusicRecommend(open);
+  } = useAiMusicRecommend();
 
   if (!open) return null;
 
@@ -117,6 +117,7 @@ export function MusicRecommendModal({
                 key={card.url}
                 title={card.title}
                 thumbnailUrl={card.thumbnailUrl}
+                durationText={card.durationText}
                 checked={selectedUrl === card.url}
                 onChange={() => handleSelect(card.url)}
               />

--- a/src/features/wake-up-music/ui/MusicRecommendModal.tsx
+++ b/src/features/wake-up-music/ui/MusicRecommendModal.tsx
@@ -7,21 +7,12 @@ import { TextButton } from "@/shared/ui/Button/TextButton";
 import RetryButton from "@/shared/ui/Button/RetryButton";
 import { useAiMusicRecommend } from "@/features/wake-up-music/model/useAiMusicRecommend";
 import { NoteText } from "@/shared/ui/NoteText";
-import { Skeleton } from "@/shared/ui/Skeleton";
+import { MusicRecommendLoading } from "@/features/wake-up-music/ui/MusicRecommendLoading";
 
 interface MusicRecommendModalProps {
   open: boolean;
   onClose: () => void;
   onSubmit: (selectedUrl: string) => Promise<void> | void;
-}
-
-function MusicRecommendCardSkeleton() {
-  return (
-    <div className="w-full shrink-0 sm:w-[calc((100%-0.75rem)/2)] lg:w-[calc((100%-1.5rem)/3)]">
-      <Skeleton className="h-[203px] w-full rounded-xl" />
-      <Skeleton className="mt-2 h-5 w-4/5" />
-    </div>
-  );
 }
 
 interface MusicRecommendEmptyProps {
@@ -60,6 +51,7 @@ export function MusicRecommendModal({
     maxRetry,
     isActive,
     isPending,
+    loadingStage,
     handleSelect,
     handleRetry,
   } = useAiMusicRecommend();
@@ -106,9 +98,7 @@ export function MusicRecommendModal({
 
         <div className="scrollbar-hide flex min-h-[230px] gap-3 overflow-x-auto">
           {isPending ? (
-            Array.from({ length: 3 }).map((_, i) => (
-              <MusicRecommendCardSkeleton key={i} />
-            ))
+            <MusicRecommendLoading stage={loadingStage ?? "recommend"} />
           ) : displayCards.length === 0 ? (
             <MusicRecommendEmpty reason={emptyReason} />
           ) : (
@@ -130,6 +120,7 @@ export function MusicRecommendModal({
             onClick={handleRetry}
             count={retryCount}
             max={maxRetry}
+            disabled={isPending}
           />
           <div
             className={

--- a/src/features/wake-up-music/ui/WakeUpMusicRecommend.tsx
+++ b/src/features/wake-up-music/ui/WakeUpMusicRecommend.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { MusicRecommendButton } from "@/features/wake-up-music/ui/MusicRecommendButton";
+import { MusicRecommendModal } from "@/features/wake-up-music/ui/MusicRecommendModal";
+import { useApplyRecommendedMusic } from "@/features/wake-up-music/model/useApplyRecommendedMusic";
+
+interface WakeUpMusicRecommendProps {
+  className?: string;
+}
+
+export function WakeUpMusicRecommend({ className }: WakeUpMusicRecommendProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { handleSubmitRecommendedMusic } = useApplyRecommendedMusic();
+
+  return (
+    <>
+      <div className={className}>
+        <MusicRecommendButton onClick={() => setIsModalOpen(true)} />
+      </div>
+
+      {isModalOpen && (
+        <MusicRecommendModal
+          open={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          onSubmit={handleSubmitRecommendedMusic}
+        />
+      )}
+    </>
+  );
+}

--- a/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
+++ b/src/features/wake-up-music/ui/WakeUpMusicSection.tsx
@@ -8,9 +8,8 @@ import { TextButton } from "@/shared/ui/Button/TextButton";
 import { NoteText } from "@/shared/ui/NoteText";
 import TextField from "@/shared/ui/textField";
 import Music from "@/shared/asset/svg/Music";
-import { MusicRecommendModal } from "@/features/wake-up-music/ui/MusicRecommendModal";
 import { MusicListModal } from "@/features/wake-up-music/ui/MusicListModal";
-import { MusicRecommendButton } from "@/features/wake-up-music/ui/MusicRecommendButton";
+import { WakeUpMusicRecommend } from "@/features/wake-up-music/ui/WakeUpMusicRecommend";
 import { useWakeUpMusic } from "@/features/wake-up-music/model/useWakeUpMusic";
 import { MusicFilterDropdown } from "@/features/wake-up-music/ui/MusicFilterDropdown";
 import { useMusicFilter } from "@/features/wake-up-music/model/useMusicFilter";
@@ -44,12 +43,10 @@ export function WakeUpMusicSection({
     canDeleteAnyMusic,
     applyMutation,
     handleApplyMusic,
-    handleSubmitRecommendedMusic,
     likeMutation,
     cancelMutation,
   } = useWakeUpMusic(filterParams);
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const [isListModalOpen, setIsListModalOpen] = useState(false);
 
   const isApplyDisabled = !isToday || !canApply || applyMutation.isPending;
@@ -143,17 +140,13 @@ export function WakeUpMusicSection({
           )}
 
           {!compact && (
-            <div className="flex justify-end">
-              <MusicRecommendButton onClick={() => setIsModalOpen(true)} />
-            </div>
+            <WakeUpMusicRecommend className="hidden lg:flex lg:justify-end" />
           )}
         </div>
       </div>
 
       {compact && (
-        <div className="absolute right-6 bottom-6">
-          <MusicRecommendButton onClick={() => setIsModalOpen(true)} />
-        </div>
+        <WakeUpMusicRecommend className="hidden lg:absolute lg:right-6 lg:bottom-6 lg:block" />
       )}
 
       {isListModalOpen && (
@@ -171,14 +164,6 @@ export function WakeUpMusicSection({
           onDelete={(musicId) => cancelMutation.mutate(musicId)}
           likeMutation={likeMutation}
           cancelMutation={cancelMutation}
-        />
-      )}
-
-      {isModalOpen && (
-        <MusicRecommendModal
-          open={isModalOpen}
-          onClose={() => setIsModalOpen(false)}
-          onSubmit={handleSubmitRecommendedMusic}
         />
       )}
     </section>

--- a/src/shared/asset/svg/VinylRecord.tsx
+++ b/src/shared/asset/svg/VinylRecord.tsx
@@ -24,7 +24,7 @@ export default function VinylRecord({
         </radialGradient>
       </defs>
 
-      <circle cx="40" cy="40" r="38" fill="var(--color-main-text)" />
+      <circle cx="40" cy="40" r="38" fill="var(--color-sub-1)" />
 
       <circle
         cx="40"

--- a/src/shared/asset/svg/VinylRecord.tsx
+++ b/src/shared/asset/svg/VinylRecord.tsx
@@ -1,0 +1,68 @@
+interface VinylRecordProps {
+  size?: number;
+  className?: string;
+}
+
+export default function VinylRecord({
+  size = 80,
+  className,
+}: VinylRecordProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 80 80"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <defs>
+        <radialGradient id="vinyl-sheen" cx="32%" cy="26%" r="78%">
+          <stop offset="0%" stopColor="#ffffff" stopOpacity="0.45" />
+          <stop offset="35%" stopColor="#ffffff" stopOpacity="0.12" />
+          <stop offset="70%" stopColor="#ffffff" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+
+      <circle cx="40" cy="40" r="38" fill="var(--color-main-text)" />
+
+      <circle
+        cx="40"
+        cy="40"
+        r="31"
+        stroke="var(--color-sub-2)"
+        strokeWidth="0.75"
+        opacity="0.45"
+      />
+      <circle
+        cx="40"
+        cy="40"
+        r="25"
+        stroke="var(--color-sub-2)"
+        strokeWidth="0.75"
+        opacity="0.45"
+      />
+      <circle
+        cx="40"
+        cy="40"
+        r="19"
+        stroke="var(--color-sub-2)"
+        strokeWidth="0.75"
+        opacity="0.45"
+      />
+
+      {/* 함께 회전하는 광택(스페큘러) — 광원 + 회전감 */}
+      <circle cx="40" cy="40" r="38" fill="url(#vinyl-sheen)" />
+      <path
+        d="M40 6 A34 34 0 0 1 74 40"
+        stroke="#ffffff"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        opacity="0.55"
+      />
+
+      {/* 중앙 라벨 (챗봇이 위에 겹쳐짐) */}
+      <circle cx="40" cy="40" r="14" fill="var(--color-p-1)" />
+    </svg>
+  );
+}

--- a/src/shared/ui/Button/RetryButton.tsx
+++ b/src/shared/ui/Button/RetryButton.tsx
@@ -4,14 +4,24 @@ interface RetryButtonProps {
   onClick: () => void;
   count: number;
   max: number;
+  disabled?: boolean;
 }
 
-export default function RetryButton({ onClick, count, max }: RetryButtonProps) {
+export default function RetryButton({
+  onClick,
+  count,
+  max,
+  disabled = false,
+}: RetryButtonProps) {
+  const isDisabled = count === max || disabled;
+
   return (
     <button
       onClick={onClick}
-      disabled={count === max}
-      className="flex cursor-pointer flex-col items-center"
+      disabled={isDisabled}
+      className={`flex flex-col items-center ${
+        isDisabled ? "pointer-events-none opacity-50" : "cursor-pointer"
+      }`}
     >
       <Retry />
       <span className="text-sub-2">


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

https://github.com/user-attachments/assets/89275ef4-0e6e-4286-8ab5-e4fa1c5f31eb

https://github.com/user-attachments/assets/76466c0c-6e11-4b58-9ef4-bda90a951205

- 노래 추천 음악 리스트에 재생시간 표시
- 추천 카드에 선택 시 체크 아이콘(자습 체크 동일 연출) 추가
- 추천 모달을 열 때 자동 추천 호출을 제거하고 재시도 버튼으로만 추천이 발생하도록 변경 
- 추천 응답 이후 YouTube 메타 조회까지 스켈레톤을 유지해 로딩 중 빈 카드 노출 제거
- 추천 로딩을 회전하는 LP판 + 챗봇 마스코트 연출로 교체하고, 실제 진행 단계(추천/영상 조회)에 맞춘 멘트 표시
- 로딩 중이거나 재시도 횟수를 모두 소진하면 새로고침 버튼을 비활성화
- 새 추천 시작 시 진행 중이던 YouTube 영상 조회를 정확한 쿼리 키로 취소
- 노래 추천 버튼을 화면 크기별로 분리: lg 미만은 전역 플로팅, lg 이상은 섹션 내 버튼

## 💬리뷰 요구사항

- [x] `lg`(1024px) 경계에서 추천 버튼이 플로팅 ↔ 섹션 내 버튼으로 전환되는지 확인 부탁드립니다.
- [x] reduced-motion 환경에서 로딩 LP 회전이 멈추는지 확인 부탁드립니다.