### PR TITLE
fix: 백그라운드 SSE 재연결로 토스트가 누적되는 문제 수정

### DIFF
--- a/src/shared/api/authorizedSse.ts
+++ b/src/shared/api/authorizedSse.ts
@@ -12,14 +12,12 @@ interface AuthorizedSseConfig {
 /**
  * 인증된 SSE에 연결한다.
  *
- * 표준 EventSource는 Authorization 헤더를 보낼 수 없어 토큰을 URL 쿼리로 싣고
- * 재연결마다 만료된 토큰을 그대로 재사용하는 한계가 있다. 여기서는 fetch 주입을
- * 지원하는 eventsource 라이브러리를 사용해, 재연결마다 호출되는 fetch가
- * sessionStorage의 최신 access_token을 Authorization 헤더로 싣는다.
+ * fetch 주입을 지원하는 eventsource 라이브러리로 재연결마다 sessionStorage의
+ * 최신 access_token을 Authorization 헤더에 싣는다. 401이면 refreshAccessToken()으로
+ * 1회 재시도하고, 그래도 실패하면 401을 그대로 반환해 재연결을 멈춘다.
  *
- * - 401이면 공유 refreshAccessToken()으로 갱신해 1회 재시도한다.
- * - 갱신까지 실패하면 401을 그대로 반환해 라이브러리가 재연결을 멈춘다(무한 루프 방지).
- * - 단순 네트워크 드롭의 재연결·Last-Event-ID는 라이브러리에 위임한다.
+ * 백그라운드(hidden)에서 끊기면 재연결 churn으로 토스트가 누적되므로 재시도하지 않고,
+ * visible 복귀 시 한 번만 재연결한다.
  *
  * @returns 정리(cleanup) 함수
  */
@@ -45,13 +43,34 @@ export function openAuthorizedSse({
     return refreshed ? request(refreshed) : response;
   };
 
-  const eventSource = new EventSource(path, { fetch: fetchWithAuth });
+  let eventSource: EventSource | null = null;
 
-  eventSource.addEventListener("open", () => onOpen?.());
-  eventSource.addEventListener("error", () => onError?.());
-  for (const [type, handler] of Object.entries(listeners)) {
-    eventSource.addEventListener(type, handler);
-  }
+  const connect = () => {
+    const source = new EventSource(path, { fetch: fetchWithAuth });
+    eventSource = source;
 
-  return () => eventSource.close();
+    source.addEventListener("open", () => onOpen?.());
+    source.addEventListener("error", () => {
+      onError?.();
+      if (document.visibilityState === "hidden") {
+        source.close();
+        eventSource = null;
+      }
+    });
+    for (const [type, handler] of Object.entries(listeners)) {
+      source.addEventListener(type, handler);
+    }
+  };
+
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "visible" && !eventSource) connect();
+  };
+
+  connect();
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+
+  return () => {
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    eventSource?.close();
+  };
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 탭이 백그라운드(`hidden`) 상태일 때 SSE 연결이 끊기면 자동 재연결을 멈추도록 변경
- 다시 포그라운드(`visible`)로 돌아올 때 한 번만 재연결하도록 `visibilitychange` 처리 추가
- 오래 백그라운드에 둔 뒤 복귀하면 연결/끊김 반복으로 쌓인 토스트가 한꺼번에 뜨던 문제 해소

## 💬리뷰 요구사항

- 상용환경에서 `visibilityState`가 `visible` 복귀 시 SSE 요청이 1회만 새로 생기는지 확인 부탁드립니다.
- 24시간 이후 http://ssh.gsmsv.site:25116/ 개발 서버에서 테스트를 완료하였습니다.