### PR TITLE
chore: 릴리즈 PR 제목 검사를 별도 워크플로로 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,6 @@ on:
 
 jobs:
   # ─────────────────────────────────────────────
-  # 0. develop → main 릴리즈 PR 식별자 검사
-  # ─────────────────────────────────────────────
-  release-version-check:
-    name: Release ID Check
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: 릴리즈 PR 제목 검사
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          if [[ ! "$PR_TITLE" =~ ^v[0-9]{4}\.[0-9]{4}\.[0-9]{4}$ ]]; then
-            echo "develop → main PR 제목은 vYYYY.MMDD.HHmm 형식이어야 합니다. 예: v2026.0510.0109"
-            echo "현재 PR 제목: $PR_TITLE"
-            exit 1
-          fi
-
-  # ─────────────────────────────────────────────
   # 1. ESLint 린트 검사
   # ─────────────────────────────────────────────
   lint:
@@ -79,13 +59,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [release-version-check, lint, type-check, format-check]
-    if: |
-      always() &&
-      needs.lint.result == 'success' &&
-      needs.type-check.result == 'success' &&
-      needs.format-check.result == 'success' &&
-      (needs.release-version-check.result == 'success' || needs.release-version-check.result == 'skipped')
+    needs: [lint, type-check, format-check]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -101,7 +75,7 @@ jobs:
   discord-ci-failure:
     name: Discord CI 실패 알림
     runs-on: ubuntu-latest
-    needs: [release-version-check, lint, type-check, format-check, build]
+    needs: [lint, type-check, format-check, build]
     if: failure()
     steps:
       - name: Discord 알림 전송

--- a/.github/workflows/release-title-check.yml
+++ b/.github/workflows/release-title-check.yml
@@ -1,0 +1,25 @@
+name: Release Title Check
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  release-version-check:
+    name: Release ID Check
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.ref == 'develop'
+    steps:
+      - name: 릴리즈 PR 제목 검사
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ ! "$PR_TITLE" =~ ^v[0-9]{4}\.[0-9]{4}\.[0-9]{4}$ ]]; then
+            echo "develop → main PR 제목은 vYYYY.MMDD.HHmm 형식이어야 합니다. 예: v2026.0510.0109"
+            echo "현재 PR 제목: $PR_TITLE"
+            exit 1
+          fi


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 릴리즈 PR 제목 검사를 `release-title-check.yml` 워크플로로 분리하고, `pull_request` `edited` 이벤트를 트리거에 추가해 제목 수정 시 최신 페이로드로 자동 재검사되도록 변경했습니다.
- `ci.yml`에서 `release-version-check` 잡을 제거하고, `build`·`discord-ci-failure` 잡의 `needs`에서 해당 의존성과 관련 `if` 분기를 정리했습니다.

## 💬리뷰 요구사항

- 제목 검사 잡이 `ci.yml`에서 분리되면서 `build`와의 `needs` 게이트가 끊겼습니다. 머지 차단을 유지하려면 `main` 브랜치 보호 규칙에서 `Release ID Check`를 필수 status check로 지정해야 합니다.